### PR TITLE
feat: Adds new Spire guide

### DIFF
--- a/src/internal/command/guidefetch/guide.go
+++ b/src/internal/command/guidefetch/guide.go
@@ -37,6 +37,13 @@ var (
 		GDriveUrl:      "https://drive.google.com/drive/folders/17lB7m9KQMwzBb6UHfoBt9ZEA82haD2Fd?usp=sharing",
 	}
 
+	spire = &Guide{
+		Name:           "Spire of the Watcher",
+		SubCommandName: "dungeon-spire",
+		Description:    "Spire of the Watcher Dungeon",
+		GDriveUrl:      "https://drive.google.com/drive/folders/1Xu_8NfiPFnknocqdR8p9adWPF-qiHmxo?usp=share_link",
+	}
+
 	vault = &Guide{
 		Name:           "Vault of Glass",
 		SubCommandName: "raid-vault",
@@ -64,6 +71,7 @@ var (
 		*garden,
 		*kingsfall,
 		*pit,
+		*spire,
 		*vault,
 		*vow,
 		*wish,

--- a/src/internal/command/guidefetch/guidefetch.go
+++ b/src/internal/command/guidefetch/guidefetch.go
@@ -37,6 +37,8 @@ var (
 				content = guideMessage(i, wish.Name, wish.GDriveUrl)
 			case pit.SubCommandName:
 				content = guideMessage(i, pit.Name, pit.GDriveUrl)
+			case spire.SubCommandName:
+				content = guideMessage(i, spire.Name, spire.GDriveUrl)
 			default:
 				content = "Oops, something has gone wrong!\n"
 				log.Printf("fetch-guide has ran into `default` in switch statement! Value: %v", i.ApplicationCommandData().Options[0].Name)


### PR DESCRIPTION
# Purpose :dart:

This change adds a new guide for the `Spire of the Watcher` dungeon in Destiny 2 as a sub-command, for ease of access to our curated Destiny guides.

# Context :brain:

The new Spire of the Watcher Dungeon is out on Destiny 2 :)
