### PR TITLE
fix: Renovate Config is cooked?

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,7 +22,7 @@
     },
     {
       "matchManagers": ["github-actions"],
-      "matchFiles": [".github/workflows/"],
+      "matchPaths": [".github/workflows/"],
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,7 +41,6 @@
       "automergeStrategy": "squash"
     },
     {
-      "groupName": "linting-specific dependencies",
       "matchDepTypes": ["devDependencies"],
       "matchPackagePatterns": ["lint", "prettier"],
       "automerge": true,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -60,12 +60,7 @@
     {
       "groupName": "nodejs",
       "allowedVersions": "^18.0.0",
-      "matchPackageNames": [
-        "@types/node",
-        "node",
-        "public.ecr.aws/docker/library/node"
-      ],
-      "matchManagers": ["dockerfile", "npm"],
+      "matchPackageNames": ["node", "@types/node"],
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -39,8 +39,8 @@
       "automergeStrategy": "squash"
     },
     {
-      "matchDepTypes": ["devDependencies"],
-      "matchPackagePatterns": ["lint", "prettier"],
+      "groupName": "eslint",
+      "matchPackagePrefixes": ["@typescript-eslint/", "eslint"],
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true,
@@ -56,8 +56,17 @@
     },
     {
       "groupName": "nodejs",
+      "matchPackageNames": ["@types/node", "ts-node"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true,
+      "automergeStrategy": "squash"
+    },
+    {
+      "groupName": "nodejs",
       "allowedVersions": "^18.0.0",
-      "matchPackageNames": ["node", "@types/node"],
+      "matchPackageNames": ["node"],
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,12 +30,10 @@
     },
     {
       "matchManagers": ["gomod"],
-      "automerge": false,
       "automergeStrategy": "squash"
     },
     {
       "groupName": "golang",
-      "automerge": false,
       "matchManagers": ["gomod"],
       "matchPackageNames": ["go"],
       "automergeStrategy": "squash"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,9 +36,8 @@
     {
       "groupName": "golang",
       "automerge": false,
-      "allowedVersions": "^1.19.0",
-      "matchManagers": ["dockerfile", "gomod"],
-      "matchPackageNames": ["go", "public.ecr.aws/docker/library/golang"],
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["go"],
       "automergeStrategy": "squash"
     },
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", ":dependencyDashboard"],
+  "ignorePaths": ["src/Dockerfile", "ops/Dockerfile"],
   "schedule": ["after 7am and before 7pm every weekday"],
   "automergeSchedule": ["after 7am and before 7pm every weekday"],
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,40 +12,51 @@
     "platformAutomerge": true,
     "automergeStrategy": "squash"
   },
-  "platformAutomerge": true,
-  "automergeStrategy": "squash",
-  "automergeType": "pr",
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true,
+      "automergeStrategy": "squash"
     },
     {
       "matchManagers": ["github-actions"],
       "matchFiles": [".github/workflows/"],
-      "automerge": true
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true,
+      "automergeStrategy": "squash"
     },
     {
       "matchManagers": ["gomod"],
-      "automerge": false
+      "automerge": false,
+      "automergeStrategy": "squash"
     },
     {
       "groupName": "golang",
       "automerge": false,
       "allowedVersions": "^1.19.0",
       "matchManagers": ["dockerfile", "gomod"],
-      "matchPackageNames": ["go", "public.ecr.aws/docker/library/golang"]
+      "matchPackageNames": ["go", "public.ecr.aws/docker/library/golang"],
+      "automergeStrategy": "squash"
     },
     {
       "groupName": "linting-specific dependencies",
       "matchDepTypes": ["devDependencies"],
       "matchPackagePatterns": ["lint", "prettier"],
-      "automerge": true
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true,
+      "automergeStrategy": "squash"
     },
     {
       "groupName": "jest",
       "matchPackageNames": ["jest", "ts-jest", "@types/jest"],
-      "automerge": true
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true,
+      "automergeStrategy": "squash"
     },
     {
       "groupName": "nodejs",
@@ -56,13 +67,19 @@
         "public.ecr.aws/docker/library/node"
       ],
       "matchManagers": ["dockerfile", "npm"],
-      "automerge": true
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true,
+      "automergeStrategy": "squash"
     },
     {
       "groupName": "aws-cdk",
       "matchPackageNames": ["constructs", "aws-cdk", "aws-cdk-lib"],
       "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true,
+      "automergeStrategy": "squash"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", ":dependencyDashboard"],
-  "schedule": ["after 8pm and before 8am every weekday"],
-  "automergeSchedule": ["after 8pm and before 8am every weekday"],
+  "schedule": ["after 7am and before 7pm every weekday"],
+  "automergeSchedule": ["after 7am and before 7pm every weekday"],
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "lockFileMaintenance": {
     "enabled": true,


### PR DESCRIPTION
# Purpose :dart:

These changes aim to bring `renovate` configurations back to a working state. Rather than continuously release attempted fixes, we are rewinding and will add the changes piece-meal.

# Context :brain:

Since commit d8a66afeca69c9853ccb813818dde80798ff4371, `renovate` has not been automerging its changes. This PR reverts all configuration changes to `renovate`.
