### PR TITLE
Renovate tweaks

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,14 +27,12 @@
       "automerge": true
     },
     {
-      "matchManagers": ["gomod"],
-      "automergeStrategy": "squash"
+      "matchManagers": ["gomod"]
     },
     {
       "groupName": "golang",
       "matchManagers": ["gomod"],
-      "matchPackageNames": ["go"],
-      "automergeStrategy": "squash"
+      "matchPackageNames": ["go"]
     },
     {
       "groupName": "linting",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,10 +27,12 @@
       "automerge": true
     },
     {
-      "matchManagers": ["gomod"]
+      "matchManagers": ["gomod"],
+      "automerge": false
     },
     {
       "groupName": "golang",
+      "automerge": false,
       "matchManagers": ["gomod"],
       "matchPackageNames": ["go"]
     },


### PR DESCRIPTION
# Purpose :dart:

These changes disable automerging of `golang` deps. This is due to lack of comprehensive testing to verify that `ralphbot` will still work after a dependency update.

# Context :brain:

Brings back changes from: https://github.com/therealvio-org/ralphbot/pull/234
