### PR TITLE
chore: matchFiles is too fiddly

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,7 +23,6 @@
     },
     {
       "matchManagers": ["github-actions"],
-      "matchFiles": [".github/workflows/"],
       "automerge": true
     },
     {


### PR DESCRIPTION
# Purpose :dart:

These changes remove the `matchPaths` configuration property. `matchPaths` is being deprecated, and `matchFiles` is too fiddly for multiple files.

# Context :brain:

Cleans up `renovate` configurations.
