### PR TITLE
chore: Updates go to 1.20 (#297)Co-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 direnv 2.32.2
-golang 1.19.5
+golang 1.20.1
 yarn 1.22.19
 nodejs 18.14.0

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.19 as build_image
+FROM public.ecr.aws/docker/library/golang:1.20 as build_image
 
 #Build the fargate binary when the "build-deployment-binary" argument is passed, or use "make build" target by default
 #This argument shouldn't need to be used in a local development context unless testing the use of the argument

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module ralphbot
 
-go 1.19
+go 1.20
 
 require (
 	github.com/bwmarrin/discordgo v0.27.0

--- a/src/internal/command/dadjoke/dadjoke.go
+++ b/src/internal/command/dadjoke/dadjoke.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"math/rand"
 	"os"
-	"time"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -58,7 +57,6 @@ func getJokes() []string {
 }
 
 func dadJoke(i *discordgo.InteractionCreate, j []string) string {
-	rand.Seed(time.Now().Unix())
 	selectedDadJoke := j[rand.Intn(len(j))]
 	result := string(selectedDadJoke)
 	return result


### PR DESCRIPTION
Updates golang to 1.20, featuring all other `renovate` PRs that are updating `golang` seperately.

This will eventually be fixed...
