### PR TITLE
chore: Disables automerge for renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,11 +19,11 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
+      "automerge": false
     },
     {
       "matchManagers": ["github-actions"],
-      "automerge": true
+      "automerge": false
     },
     {
       "matchManagers": ["gomod"],
@@ -44,24 +44,24 @@
         "eslint-plugin-import",
         "prettier"
       ],
-      "automerge": true
+      "automerge": false
     },
     {
       "groupName": "jest",
       "matchPackageNames": ["jest", "ts-jest", "@types/jest"],
-      "automerge": true
+      "automerge": false
     },
     {
       "groupName": "nodejs",
       "allowedVersions": "^18.0.0",
       "matchPackageNames": ["node", "@types/node"],
-      "automerge": true
+      "automerge": false
     },
     {
       "groupName": "aws-cdk",
       "matchPackageNames": ["constructs", "aws-cdk", "aws-cdk-lib"],
       "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
# Purpose :dart:

These changes disable `renovate` automerging`. Renovate is once again cooked, and the config needs fixing... again... 💀 

First thing is first, while the configuration is messy, automerging has been disabled so that dependencies are grouped properly when `renovate` is fixed again.
