### PR TITLE
Attempts to fix renovate part #3 2023 edition

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,7 +35,7 @@
       "groupName": "golang",
       "automerge": false,
       "matchDatasources": ["golang-version"],
-      "matchManagers": ["gomod", "asdf"],
+      "matchManagers": ["asdf", "dockerfile", "gomod"],
       "rangeStrategy": "bump"
     },
     {
@@ -64,7 +64,7 @@
       "groupName": "nodejs",
       "allowedVersions": "^18.0.0",
       "matchDatasources": ["node"],
-      "matchManagers": ["asdf"],
+      "matchManagers": ["asdf", "dockerfile"],
       "matchPackageNames": ["node"],
       "automerge": false
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -57,6 +57,7 @@
     {
       "groupName": "nodejs",
       "allowedVersions": "^18.0.0",
+      "matchManagers": ["npm"],
       "matchPackageNames": ["node", "@types/node"],
       "automerge": false
     },


### PR DESCRIPTION
# Purpose :dart:

These changes attempt to fix renovate's cooked config for this repository.

The `dockerfile` and `npm` package managers have been explicitly configured in the renovate config. Hopefully, this should help with better grouping tooling versioning for `nodejs` and `golang`.