### PR TITLE
Sets nodejs docker image to 18.13

### DIFF
--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/node:18-alpine
+FROM public.ecr.aws/docker/library/node:18.13-alpine
 
 WORKDIR /cdk
 


### PR DESCRIPTION
# Purpose :dart:

This change revers the nodejs version of the `ops` stack container image. The aim of this is to "play nice" with how `renovate` manages versioning of images from Dockerhub.

At the time of writing this, the theory is, that versions like 18-alpine, will increment to 19-alpine, whereas: 18.13-alpine, would increment to 18.14-alpine. Thus, the image version stays within verison "18", and the increment happens within the minor version, rather than major version. Luckily, the reference image exercises this versioning behaviour, so we can take advantage of this.

# Notes 📓 

- [renovate docs - Docker Versioning](https://docs.renovatebot.com/modules/versioning/#docker-versioning)
