### PR TITLE
chore: Schedule renovate to run during after office hours

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", ":dependencyDashboard"],
-  "schedule": ["after 7am and before 7pm every weekday"],
-  "automergeSchedule": ["after 7am and before 7pm every weekday"],
+  "timezone": "Australia/Melbourne",
+  "schedule": [
+    "after 8pm every weekday",
+    "before 8am every weekday",
+    "every weekend"
+  ],
+  "automergeSchedule": [
+    "after 8pm every weekday",
+    "before 8am every weekday",
+    "every weekend"
+  ],
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "lockFileMaintenance": {
     "enabled": true,


### PR DESCRIPTION
# Purpose 🎯 

Giving `renovate` more time to do its thing. Confidence in tests on the CDK side of things are pretty good - so there is no reason why we need to restrict things as much as they were previously.
