### PR TITLE
chore: Renames RoN to tRoN

### DIFF
--- a/src/internal/command/guidefetch/guide.go
+++ b/src/internal/command/guidefetch/guide.go
@@ -38,9 +38,9 @@ var (
 	}
 
 	ron = &Guide{
-		Name:           "Root of Nightmares",
-		SubCommandName: "raid-ron",
-		Description:    "Root of Nightmares Raid",
+		Name:           "The Root of Nightmares",
+		SubCommandName: "raid-tron",
+		Description:    "The Root of Nightmares Raid",
 		GDriveUrl:      "https://drive.google.com/drive/folders/1eR50Jt36GBegMALRkT-tmnH6Nnjc4Pqj?usp=share_link",
 	}
 


### PR DESCRIPTION
# Purpose :dart:

The raid: `Root of Nightmares" is really called "The Root of Nightmares", which can be abbreviated as "tRoN". This sounds way better than "RoN", so we're going to call it that going forward. 