### PR TITLE
chore: Adds testing to `bot` component of the `discord` package

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -15,5 +15,4 @@ RUN make ${MAKE_TARGET}
 FROM public.ecr.aws/docker/library/alpine:latest
 WORKDIR /app
 COPY --from=build_image /app/bin/ralphbot ./
-COPY --from=build_image /app/internal/command/dadjoke/jokes.json ./
 CMD [ "./ralphbot" ]

--- a/src/cmd/ralphbot/main.go
+++ b/src/cmd/ralphbot/main.go
@@ -5,25 +5,21 @@ import (
 
 	"ralphbot/internal/config"
 	"ralphbot/internal/discord"
-
-	"github.com/bwmarrin/discordgo"
 )
 
 var (
 	env = config.New()
 )
 
-var s *discordgo.Session
-
-func init() {
-	var err error
-	s, err = discordgo.New("Bot " + env.BotToken)
-	if err != nil {
-		log.Fatalf("Error creating new Discord session: %v", err)
-	}
-}
-
 func main() {
-	discord.CheckGuildId(s, env.GuildID)
-	discord.StartBotService(s, env)
+	ds, err := discord.NewDiscord(env.BotToken)
+	if err != nil {
+		log.Fatalf("Error executing NewDiscord(): %v", err)
+	}
+
+	// pre-flight checks go here
+	discord.CheckGuildId(ds, env.GuildID)
+
+	// launch! 🚀
+	discord.StartBotService(ds, env)
 }

--- a/src/cmd/ralphbot/main.go
+++ b/src/cmd/ralphbot/main.go
@@ -21,5 +21,8 @@ func main() {
 	discord.CheckGuildId(ds, env.GuildID)
 
 	// launch! 🚀
-	discord.StartBotService(ds, env)
+	err = discord.StartBotService(ds, env)
+	if err != nil {
+		log.Fatalf("Error starting new discord session: %v", err)
+	}
 }

--- a/src/cmd/ralphbot/main.go
+++ b/src/cmd/ralphbot/main.go
@@ -5,6 +5,8 @@ import (
 
 	"ralphbot/internal/config"
 	"ralphbot/internal/discord"
+
+	"github.com/bwmarrin/discordgo"
 )
 
 var (
@@ -18,6 +20,11 @@ func main() {
 	}
 
 	// pre-flight checks go here
+	// check if the session is running
+	ds.AddHandler(func(s *discordgo.Session, r *discordgo.Ready) {
+		log.Printf("Logged in as: %v#%v", s.State.User.Username, s.State.User.Discriminator)
+	})
+
 	discord.CheckGuildId(ds, env.GuildID)
 
 	// launch! 🚀

--- a/src/internal/command/dadjoke/dadjoke.go
+++ b/src/internal/command/dadjoke/dadjoke.go
@@ -1,13 +1,16 @@
 package dadjoke
 
 import (
+	_ "embed"
 	"encoding/json"
 	"log"
 	"math/rand"
-	"os"
 
 	"github.com/bwmarrin/discordgo"
 )
+
+//go:embed jokes.json
+var jokesFile []byte
 
 var (
 	Commands = []*discordgo.ApplicationCommand{
@@ -18,7 +21,7 @@ var (
 		},
 	}
 
-	jokes = getJokes()
+	jokes = getJokes(jokesFile)
 
 	CommandHandlers = map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){
 		"dad-joke": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
@@ -35,19 +38,14 @@ var (
 	}
 )
 
-type StructJokes struct {
+type JokeStruct struct {
 	Jokes []string `json:"jokes"`
 }
 
-func getJokes() []string {
-	jokesFile, err := os.ReadFile("jokes.json")
-	if err != nil {
-		log.Fatal("Unable to read jokesFile!")
-	}
+func getJokes(b []byte) []string {
 
-	jokeArray := StructJokes{}
-
-	err = json.Unmarshal([]byte(jokesFile), &jokeArray)
+	var jokeArray JokeStruct
+	err := json.Unmarshal(b, &jokeArray)
 	if err != nil {
 		log.Printf("Unable to Unmarshal : %v", err)
 	}

--- a/src/internal/discord/bot.go
+++ b/src/internal/discord/bot.go
@@ -31,27 +31,31 @@ func NewDiscord(authToken string) (*DiscordSession, error) {
 
 // Starts the `ralphbot` service, to be used after pre-flight checks
 // This should be responsible for the running service, command registration, e.t.c.
-func StartBotService(ds *DiscordSession, env *config.EnvConfig) {
+func StartBotService(ds *DiscordSession, env *config.EnvConfig) error {
 	ds.AddHandler(func(s *discordgo.Session, r *discordgo.Ready) {
 		log.Printf("Logged in as: %v#%v", s.State.User.Username, s.State.User.Discriminator)
 	})
 	err := ds.Open()
 	if err != nil {
-		log.Fatalf("Cannot open the session: %v", err)
+		err = fmt.Errorf("cannot open the session: %v", err)
+		return err
 	}
 	defer ds.Close()
 
 	_, err = registerCommand(ds, env.GuildID, guidefetch.Commands, guidefetch.CommandHandlers)
 	if err != nil {
-		fmt.Printf("error: %v", err)
+		err = fmt.Errorf("unable to register command %v error: %v", "guidefetch", err)
+		return err
 	}
 	_, err = registerCommand(ds, env.GuildID, dadjoke.Commands, dadjoke.CommandHandlers)
 	if err != nil {
-		fmt.Printf("error: %v", err)
+		err = fmt.Errorf("unable to register command %v error: %v", "dadjoke", err)
+		return err
 	}
 	_, err = registerCommand(ds, env.GuildID, linkdump.Commands, linkdump.CommandHandlers)
 	if err != nil {
-		fmt.Printf("error: %v", err)
+		err = fmt.Errorf("unable to register command %v error: %v", "linkdump", err)
+		return err
 	}
 
 	stop := make(chan os.Signal, 1)
@@ -64,4 +68,5 @@ func StartBotService(ds *DiscordSession, env *config.EnvConfig) {
 	}
 
 	log.Println("Shutting down gracefully...")
+	return nil
 }

--- a/src/internal/discord/bot.go
+++ b/src/internal/discord/bot.go
@@ -32,9 +32,6 @@ func NewDiscord(authToken string) (*DiscordSession, error) {
 // Starts the `ralphbot` service, to be used after pre-flight checks
 // This should be responsible for the running service, command registration, e.t.c.
 func StartBotService(ds *DiscordSession, env *config.EnvConfig) error {
-	ds.AddHandler(func(s *discordgo.Session, r *discordgo.Ready) {
-		log.Printf("Logged in as: %v#%v", s.State.User.Username, s.State.User.Discriminator)
-	})
 	err := ds.Open()
 	if err != nil {
 		err = fmt.Errorf("cannot open the session: %v", err)

--- a/src/internal/discord/bot_test.go
+++ b/src/internal/discord/bot_test.go
@@ -1,0 +1,22 @@
+package discord
+
+import (
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/stretchr/testify/assert"
+)
+
+// This is more of a regression test. NewDiscord() shouldn't be doing more than setting up a new session
+// additionally, if Discord.New() requires extra parameters, or returns more than just the session, this test will catch it outside of the assertions
+func TestNewDiscord(t *testing.T) {
+	// arrange
+	dgs := &discordgo.Session{}
+
+	// act
+	ds, err := NewDiscord("mockSecret123")
+
+	// assert
+	assert.NoError(t, err)
+	assert.IsType(t, dgs, ds.Session)
+}

--- a/src/internal/discord/command.go
+++ b/src/internal/discord/command.go
@@ -12,8 +12,8 @@ import (
 // Registers commands for `ralphbot` service.
 // If `GUILD_ID` is passed, then the command is set as a guild command, and will not be registered globally. However, it will be immediately registered exclusively
 // to the Discord server (guild). If `GUILD_ID` is not passed, then the command is registered globally.
-func registerCommand(s *discordgo.Session, id string, commands []*discordgo.ApplicationCommand, handler map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate)) ([]*discordgo.ApplicationCommand, error) {
-	s.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+func registerCommand(ds *DiscordSession, id string, commands []*discordgo.ApplicationCommand, handler map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate)) ([]*discordgo.ApplicationCommand, error) {
+	ds.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		if h, ok := handler[i.ApplicationCommandData().Name]; ok {
 			h(s, i)
 		}
@@ -21,7 +21,7 @@ func registerCommand(s *discordgo.Session, id string, commands []*discordgo.Appl
 
 	registeredCommands := make([]*discordgo.ApplicationCommand, len(commands))
 	for i, v := range commands {
-		cmd, err := s.ApplicationCommandCreate(s.State.User.ID, id, v)
+		cmd, err := ds.ApplicationCommandCreate(ds.State.User.ID, id, v)
 		if err != nil {
 			return nil, fmt.Errorf("cannot create command: '%v', error: %v", v.Name, err)
 		}
@@ -32,20 +32,20 @@ func registerCommand(s *discordgo.Session, id string, commands []*discordgo.Appl
 	return registeredCommands, nil
 }
 
-func deregisterCommand(s *discordgo.Session, env *config.EnvConfig) {
+func deregisterCommand(ds *DiscordSession, env *config.EnvConfig) {
 	log.Println("Removing commands...")
 	// We need to fetch the commands, since deleting requires the command ID.
 	// We are doing this from commands defined in registerCommand() runs, because using
 	// this will delete all the commands, which might not be desirable, so we
 	// are deleting only the commands that we added.
 
-	registeredCommands, err := s.ApplicationCommands(s.State.User.ID, env.GuildID)
+	registeredCommands, err := ds.ApplicationCommands(ds.State.User.ID, env.GuildID)
 	if err != nil {
 		log.Fatalf("Could not fetch registered commands: %v", err)
 	}
 
 	for _, v := range registeredCommands {
-		err := s.ApplicationCommandDelete(s.State.User.ID, env.GuildID, v.ID)
+		err := ds.ApplicationCommandDelete(ds.State.User.ID, env.GuildID, v.ID)
 		if err != nil {
 			log.Panicf("Cannot delete '%v' command: %v", v.Name, err)
 		}

--- a/src/internal/discord/guild.go
+++ b/src/internal/discord/guild.go
@@ -2,22 +2,20 @@ package discord
 
 import (
 	"log"
-
-	"github.com/bwmarrin/discordgo"
 )
 
-//If GUILD_ID was passed, it checks to see if the GUILD_ID environment variable matches the discord server's (guild) id that
-//`ralphbot` is connected to.
-//If it is, it indicates in the logs that its commands will be registered as `guild` commands, rather than `global` commands.
+// If GUILD_ID was passed, it checks to see if the GUILD_ID environment variable matches the discord server's (guild) id that
+// `ralphbot` is connected to.
+// If it is, it indicates in the logs that its commands will be registered as `guild` commands, rather than `global` commands.
 // i.e. immediate registration for the server, vs a live command
 //
-//The intention for this is to help facilitate local testing on a private server. In production, commands should be `global`.
-func CheckGuildId(s *discordgo.Session, id string) {
+// The intention for this is to help facilitate local testing on a private server. In production, commands should be `global`.
+func CheckGuildId(ds *DiscordSession, id string) {
 	doFail := false
 	if id != "" {
 		log.Printf("Checking for GuildID variable validity against current server (if it matches, we're okay)...")
 
-		g, err := s.Guild(id)
+		g, err := ds.Guild(id)
 		if err != nil {
 			log.Fatalf("Cannot retrieve Guild Id from server: %v", err)
 		}


### PR DESCRIPTION
# Purpose :dart:

These changes add a basic test to verify `discord.New()` doesn't change in behaviour from dependency updates.

This function has been moved from the `init()` function, to the `bot` portion of the `discord` package since this focuses on bot initialization and runtime.

Relevant parts of the code have been modified so that:

- They could be testable in the future
- Their errors would follow the "bubble up" behaviour, rather than occurring within themselves and exiting out.
- Indirect impact from testing was mitigated

# Context :brain:

These code changes are part of an effort to setup testing for `ralphbot`, so external API behaviour can be verified, and code is organised to be more idiomatic, less complex,  and aligns better with well known engineering principles.
