### PR TITLE
chore: D2 Gunsmith is dead, long live D2 Foundry

### DIFF
--- a/src/internal/command/linkdump/links.json
+++ b/src/internal/command/linkdump/links.json
@@ -17,8 +17,8 @@
       "URL": "https://d2checkpoint.com/"
     },
     {
-      "Name": "Destiny 2 Gunsmith",
-      "URL": "https://d2gunsmith.com/"
+      "Name": "Destiny 2 Foundry",
+      "URL": "https://d2foundry.gg/"
     },
     {
       "Name": "Destiny Item Manager (DIM)",


### PR DESCRIPTION
# Purpose :dart:

This change replaces D2 Gunsmith with the new alternative: D2 Foundry in the `linkdump` command.

# Context :brain:

D2 Gunsmith is no longer being maintained.