### PR TITLE
node deps within package.json can be automatically updated

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -70,14 +70,14 @@
     },
     {
       "groupName": "nodejs",
-      "automerge": false,
+      "automerge": true,
       "allowedVersions": "^18.0.0",
       "matchManagers": ["npm"],
       "matchPackageNames": ["node", "@types/node"]
     },
     {
       "groupName": "nodejs",
-      "automerge": false,
+      "automerge": true,
       "allowedVersions": "^18.0.0",
       "matchDatasources": ["node"],
       "matchManagers": ["asdf"],


### PR DESCRIPTION
# Purpose :dart:

It's been a while, and this scheme for `nodejs` versioning seems to do the trick. Tests should hopefully catch issues with Node-related dependencies being out-of-whack (such as Dockerfile versioning).

# Context :brain:

`dockerfile` dependency manager still lacks support for version control, but this may never happen for a long given how inconsistent tagging is for images. Though when it eventually has the ability to source version numbers from other managers as a composite type*, then we'll be in business.

* = A Dockerfile, with `semver` versioning schemes, since NodeJS Docker images honour their `semver` scheme for NodeJS.
