### PR TITLE
test: `linkdump` and `guide-fetch` now use table-driven tests

### DIFF
--- a/src/internal/command/guidefetch/guidefetch_test.go
+++ b/src/internal/command/guidefetch/guidefetch_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestGenerateCommandOptions(t *testing.T) {
-
 	backrooms := &Guide{
 		Name:           "The Backrooms",
 		SubCommandName: "raid-backrooms",
@@ -24,23 +23,53 @@ func TestGenerateCommandOptions(t *testing.T) {
 		GDriveUrl:      "https://drive.google.com/drive/folders/1d_WEa84KuX1_9hPTwgFhl651IwywHeOg?usp=sharing",
 	}
 
-	commandOptions = generateCommandOptions([]Guide{
-		*backrooms,
-		*wax,
-	})
-
-	expected := []*discordgo.ApplicationCommandOption{
+	cases := []struct {
+		name     string
+		input    []Guide
+		expected []*discordgo.ApplicationCommandOption
+	}{
 		{
-			Name:        backrooms.SubCommandName,
-			Description: backrooms.Description,
-			Type:        discordgo.ApplicationCommandOptionSubCommand,
+			name:     "when no guides are supplied, return a slice of zero ApplicationCommandOption, and an error",
+			input:    []Guide{},
+			expected: nil,
 		},
 		{
-			Name:        wax.SubCommandName,
-			Description: wax.Description,
-			Type:        discordgo.ApplicationCommandOptionSubCommand,
+			name: "when one guide is supplied, return a slice of one ApplicationCommandOption",
+			input: []Guide{
+				*backrooms,
+			},
+			expected: []*discordgo.ApplicationCommandOption{
+				{
+					Name:        backrooms.SubCommandName,
+					Description: backrooms.Description,
+					Type:        discordgo.ApplicationCommandOptionSubCommand,
+				},
+			},
+		},
+		{
+			name: "when two guides are supplied, return a slice of two ApplicationCommandOption",
+			input: []Guide{
+				*backrooms,
+				*wax,
+			},
+			expected: []*discordgo.ApplicationCommandOption{
+				{
+					Name:        backrooms.SubCommandName,
+					Description: backrooms.Description,
+					Type:        discordgo.ApplicationCommandOptionSubCommand,
+				},
+				{
+					Name:        wax.SubCommandName,
+					Description: wax.Description,
+					Type:        discordgo.ApplicationCommandOptionSubCommand,
+				},
+			},
 		},
 	}
 
-	assert.ElementsMatch(t, expected, commandOptions)
+	for _, test := range cases {
+		result := generateCommandOptions(test.input)
+		assert.Len(t, result, len(test.expected))
+		assert.ElementsMatch(t, test.expected, result)
+	}
 }

--- a/src/internal/command/linkdump/linkdump_test.go
+++ b/src/internal/command/linkdump/linkdump_test.go
@@ -12,22 +12,44 @@ func TestGetLinks(t *testing.T) {
 	foo := "foo - <foo.com>"
 	bar := "bar - <bar.com>"
 
-	linkJson := `{
-		"Links": [
-			{
-			  "Name": "foo",
-			  "URL": "foo.com"
-			},
-			{
-			  "Name": "bar",
-			  "URL": "bar.com"
-			}
-		]
-	}`
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name: "when one link is provided as input, the string contains one link",
+			input: `{
+				"Links": [
+					{
+					  "Name": "foo",
+					  "URL": "foo.com"
+					}
+				]
+			}`,
+			expected: foo,
+		},
+		{
+			name: "when 2 links are provided as input, the string contains two links, seperated by newline",
+			input: `{
+				"Links": [
+					{
+					  "Name": "foo",
+					  "URL": "foo.com"
+					},
+					{
+					  "Name": "bar",
+					  "URL": "bar.com"
+					}
+				]
+			}`,
+			expected: fmt.Sprintf("%s\n%s", foo, bar),
+		},
+	}
 
-	expected := fmt.Sprintf("%s\n%s", foo, bar)
-	links, err := getLinks([]byte(linkJson))
-
-	assert.NoError(t, err)
-	assert.Equal(t, expected, links)
+	for _, test := range cases {
+		result, err := getLinks([]byte(test.input))
+		assert.NoError(t, err)
+		assert.Equal(t, test.expected, result)
+	}
 }


### PR DESCRIPTION
# Purpose :dart:

These changes implement table-driven tests to help make testing for different scenarios more feasible as they come up. Although this change could be seen as a premature optimisation, it's nice to have this out of the way when a new scenario comes up.

# Context :brain:

short version: [Table Drive test good](https://dave.cheney.net/2019/05/07/prefer-table-driven-tests)
longer version: Table driven tests allow scenarios to be tested in an extensible fashion.  Within the `golang`-verse, this is the preferred practice when setting up, and running tests.
