### PR TITLE
refactor: command packages are decomposed

### DIFF
--- a/src/internal/command/dadjoke/dadjoke.go
+++ b/src/internal/command/dadjoke/dadjoke.go
@@ -12,32 +12,6 @@ import (
 //go:embed jokes.json
 var jokesFile []byte
 
-var (
-	Commands = []*discordgo.ApplicationCommand{
-		//https://discord.com/developers/docs/interactions/application-commands#slash-commands
-		{
-			Name:        "dad-joke",
-			Description: "Does this really need a description?",
-		},
-	}
-
-	jokes = getJokes(jokesFile)
-
-	CommandHandlers = map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){
-		"dad-joke": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
-			err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-				Type: discordgo.InteractionResponseChannelMessageWithSource,
-				Data: &discordgo.InteractionResponseData{
-					Content: dadJoke(i, jokes),
-				},
-			})
-			if err != nil {
-				log.Printf("Failed to respond to interaction: %v", err)
-			}
-		},
-	}
-)
-
 type JokeStruct struct {
 	Jokes []string `json:"jokes"`
 }
@@ -58,4 +32,32 @@ func dadJoke(i *discordgo.InteractionCreate, j []string) string {
 	selectedDadJoke := j[rand.Intn(len(j))]
 	result := string(selectedDadJoke)
 	return result
+}
+
+func GetCommands() []*discordgo.ApplicationCommand {
+	return []*discordgo.ApplicationCommand{
+		//https://discord.com/developers/docs/interactions/application-commands#slash-commands
+		{
+			Name:        "dad-joke",
+			Description: "Does this really need a description?",
+		},
+	}
+}
+
+func GetCommandHandlers() (map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate), error) {
+	jokes := getJokes(jokesFile)
+
+	return map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){
+		"dad-joke": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Content: dadJoke(i, jokes),
+				},
+			})
+			if err != nil {
+				log.Printf("Failed to respond to interaction: %v", err)
+			}
+		},
+	}, nil
 }

--- a/src/internal/command/guidefetch/guide.go
+++ b/src/internal/command/guidefetch/guide.go
@@ -1,6 +1,6 @@
 package guidefetch
 
-type Guide struct {
+type guide struct {
 	Name           string
 	SubCommandName string
 	Description    string
@@ -9,56 +9,56 @@ type Guide struct {
 }
 
 var (
-	crypt = &Guide{
+	crypt = &guide{
 		Name:           "Deep Stone Crypt",
 		SubCommandName: "raid-crypt",
 		Description:    "Deep Stone Crypt Raid",
 		GDriveUrl:      "https://drive.google.com/drive/folders/1YKU4_-hInHQ3rVEAvqIjdJaT25oQvmYc?usp=sharing",
 	}
 
-	garden = &Guide{
+	garden = &guide{
 		Name:           "Garden of Salvation",
 		SubCommandName: "raid-garden",
 		Description:    "Garden of Salvation Raid",
 		GDriveUrl:      "https://drive.google.com/drive/folders/1pPdtAptJMaaDYRv2i-8bfaL6l3I0WTsT?usp=sharing",
 	}
 
-	kingsfall = &Guide{
+	kingsfall = &guide{
 		Name:           "King's Fall",
 		SubCommandName: "raid-kingsfall",
 		Description:    "King's Fall Raid",
 		GDriveUrl:      "https://drive.google.com/drive/folders/1tsOVCy2SwP0rLUDQUJaDIFh5y-O0DoKn",
 	}
 
-	pit = &Guide{
+	pit = &guide{
 		Name:           "Pit of Heresy",
 		SubCommandName: "dungeon-pit",
 		Description:    "Pit of Heresy Dungeon",
 		GDriveUrl:      "https://drive.google.com/drive/folders/17lB7m9KQMwzBb6UHfoBt9ZEA82haD2Fd?usp=sharing",
 	}
 
-	ron = &Guide{
+	ron = &guide{
 		Name:           "The Root of Nightmares",
 		SubCommandName: "raid-tron",
 		Description:    "The Root of Nightmares Raid",
 		GDriveUrl:      "https://drive.google.com/drive/folders/1eR50Jt36GBegMALRkT-tmnH6Nnjc4Pqj?usp=share_link",
 	}
 
-	spire = &Guide{
+	spire = &guide{
 		Name:           "Spire of the Watcher",
 		SubCommandName: "dungeon-spire",
 		Description:    "Spire of the Watcher Dungeon",
 		GDriveUrl:      "https://drive.google.com/drive/folders/1Xu_8NfiPFnknocqdR8p9adWPF-qiHmxo?usp=share_link",
 	}
 
-	vault = &Guide{
+	vault = &guide{
 		Name:           "Vault of Glass",
 		SubCommandName: "raid-vault",
 		Description:    "Vault of Glass Raid",
 		GDriveUrl:      "https://drive.google.com/drive/folders/1HLx6nVIji_3OcwnzaLeSoksspa4pfdjD?usp=sharing",
 	}
 
-	vow = &Guide{
+	vow = &guide{
 		Name:           "Vow of the Disciple",
 		SubCommandName: "raid-vow",
 		Description:    "Vow of the Disciple Raid",
@@ -66,14 +66,14 @@ var (
 		GHUrl:          "https://github.com/therealvio/destiny-guides/tree/main/raids/vow-of-the-disciple",
 	}
 
-	wish = &Guide{
+	wish = &guide{
 		Name:           "Last Wish",
 		SubCommandName: "raid-lastwish",
 		Description:    "Last Wish Raid",
 		GDriveUrl:      "https://drive.google.com/drive/folders/1d_WEa84KuX1_9hPTwgFhl651IwywHeOg?usp=sharing",
 	}
 
-	guides = []Guide{
+	guides = []guide{
 		*crypt,
 		*garden,
 		*kingsfall,

--- a/src/internal/command/guidefetch/guidefetch.go
+++ b/src/internal/command/guidefetch/guidefetch.go
@@ -8,7 +8,7 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-func generateCommandOptions(g []Guide) ([]*discordgo.ApplicationCommandOption, error) {
+func generateCommandOptions(g []guide) ([]*discordgo.ApplicationCommandOption, error) {
 	var subCommands []*discordgo.ApplicationCommandOption
 
 	if g == nil {
@@ -42,44 +42,39 @@ func GetCommands() ([]*discordgo.ApplicationCommand, error) {
 }
 
 func GetCommandHandlers() map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate) {
-
 	return map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){
 		"fetch-guide": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
-			content := ""
-			switch i.ApplicationCommandData().Options[0].Name {
-			case crypt.SubCommandName:
-				content = guideMessage(i, crypt.Name, crypt.GDriveUrl)
-			case garden.SubCommandName:
-				content = guideMessage(i, garden.Name, garden.GDriveUrl)
-			case kingsfall.SubCommandName:
-				content = guideMessage(i, kingsfall.Name, kingsfall.GDriveUrl)
-			case pit.SubCommandName:
-				content = guideMessage(i, pit.Name, pit.GDriveUrl)
-			case ron.SubCommandName:
-				content = guideMessage(i, ron.Name, ron.GDriveUrl)
-			case spire.SubCommandName:
-				content = guideMessage(i, spire.Name, spire.GDriveUrl)
-			case vault.SubCommandName:
-				content = guideMessage(i, vault.Name, vault.GDriveUrl)
-			case vow.SubCommandName:
-				content = guideGithub(i, vow.Name, vow.GHUrl, vow.GDriveUrl)
-			case wish.SubCommandName:
-				content = guideMessage(i, wish.Name, wish.GDriveUrl)
-			default:
-				content = "Oops, something has gone wrong!\n"
-				log.Printf("fetch-guide has ran into `default` in switch statement! Value: %v", i.ApplicationCommandData().Options[0].Name)
-			}
-			err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-				Type: discordgo.InteractionResponseChannelMessageWithSource,
-				Data: &discordgo.InteractionResponseData{
-					Content: content,
-				},
-			})
+			response := getInteractionResponse(i)
+			err := s.InteractionRespond(i.Interaction, response)
 			if err != nil {
 				log.Printf("Failed to respond to interaction: %v", err)
 			}
 		},
 	}
+}
+
+func getInteractionResponse(i *discordgo.InteractionCreate) *discordgo.InteractionResponse {
+	response := &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: "",
+		},
+	}
+
+	for _, g := range guides {
+		if i.ApplicationCommandData().Options[0].Name == g.SubCommandName {
+			if g.GHUrl != "" {
+				response.Data.Content = guideGithub(i, g.Name, g.GHUrl, g.GDriveUrl)
+				return response
+			}
+			response.Data.Content = guideMessage(i, g.Name, g.GDriveUrl)
+			return response
+		}
+	}
+
+	response.Data.Content = "Oops, your command didn't return a guide message!\n"
+	log.Printf("fetch-guide has ran into `default` in switch statement! Value: %v", i.ApplicationCommandData().Options[0].Name)
+	return response
 }
 
 func guideMessage(i *discordgo.InteractionCreate, activity string, link string) string {

--- a/src/internal/command/guidefetch/guidefetch_test.go
+++ b/src/internal/command/guidefetch/guidefetch_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestGenerateCommandOptions(t *testing.T) {
-	backrooms := &Guide{
+	backrooms := &guide{
 		Name:           "The Backrooms",
 		SubCommandName: "raid-backrooms",
 		Description:    "The Backrooms Raid",
@@ -16,7 +16,7 @@ func TestGenerateCommandOptions(t *testing.T) {
 		GHUrl:          "https://github.com/butterdog/destiny-guides/tree/main/raids/the-backrooms",
 	}
 
-	wax := &Guide{
+	wax := &guide{
 		Name:           "Wax Museum",
 		SubCommandName: "raid-wax",
 		Description:    "The Wax Museum Raid",
@@ -25,17 +25,17 @@ func TestGenerateCommandOptions(t *testing.T) {
 
 	cases := []struct {
 		name     string
-		input    []Guide
+		input    []guide
 		expected []*discordgo.ApplicationCommandOption
 	}{
 		{
 			name:     "when no guides are supplied, return a slice of zero ApplicationCommandOption, and an error",
-			input:    []Guide{},
+			input:    []guide{},
 			expected: nil,
 		},
 		{
 			name: "when one guide is supplied, return a slice of one ApplicationCommandOption",
-			input: []Guide{
+			input: []guide{
 				*backrooms,
 			},
 			expected: []*discordgo.ApplicationCommandOption{
@@ -48,7 +48,7 @@ func TestGenerateCommandOptions(t *testing.T) {
 		},
 		{
 			name: "when two guides are supplied, return a slice of two ApplicationCommandOption",
-			input: []Guide{
+			input: []guide{
 				*backrooms,
 				*wax,
 			},

--- a/src/internal/command/guidefetch/guidefetch_test.go
+++ b/src/internal/command/guidefetch/guidefetch_test.go
@@ -68,7 +68,8 @@ func TestGenerateCommandOptions(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		result := generateCommandOptions(test.input)
+		result, err := generateCommandOptions(test.input)
+		assert.NoError(t, err)
 		assert.Len(t, result, len(test.expected))
 		assert.ElementsMatch(t, test.expected, result)
 	}

--- a/src/internal/discord/service.go
+++ b/src/internal/discord/service.go
@@ -49,17 +49,37 @@ func StartBotService(ds *DiscordSession, env *config.EnvConfig) error {
 	}
 	defer ds.Close()
 
-	_, err = registerCommand(ds, env.GuildID, guidefetch.Commands, guidefetch.CommandHandlers)
+	// guide fetch
+	commandGF, err := guidefetch.GetCommands()
+	if err != nil {
+		err = fmt.Errorf("unable to prepare command for %v error: %v", "guidefetch", err)
+		return err
+	}
+	_, err = registerCommand(ds, env.GuildID, commandGF, guidefetch.GetCommandHandlers())
 	if err != nil {
 		err = fmt.Errorf("unable to register command %v error: %v", "guidefetch", err)
 		return err
 	}
-	_, err = registerCommand(ds, env.GuildID, dadjoke.Commands, dadjoke.CommandHandlers)
+
+	// dadjoke
+	commandHandlerDJ, err := dadjoke.GetCommandHandlers()
+	if err != nil {
+		err = fmt.Errorf("unable to prepare command handlers for %v error: %v", "dadjoke", err)
+		return err
+	}
+	_, err = registerCommand(ds, env.GuildID, dadjoke.GetCommands(), commandHandlerDJ)
 	if err != nil {
 		err = fmt.Errorf("unable to register command %v error: %v", "dadjoke", err)
 		return err
 	}
-	_, err = registerCommand(ds, env.GuildID, linkdump.Commands, linkdump.CommandHandlers)
+
+	// linkdump
+	commandHandlerLD, err := linkdump.GetCommandHandlers()
+	if err != nil {
+		err = fmt.Errorf("unable to prepare command handlers for %v error: %v", "linkdump", err)
+		return err
+	}
+	_, err = registerCommand(ds, env.GuildID, linkdump.GetCommands(), commandHandlerLD)
 	if err != nil {
 		err = fmt.Errorf("unable to register command %v error: %v", "linkdump", err)
 		return err


### PR DESCRIPTION
# Purpose :dart:

This PR features refactoring of the individual command packages. This includes replacing of most global variables with functions that generate the value, and decomposition of larger functions. In particular, a nasty switch statement that required continuous extending each time new information was added into the guides library.

# Context :brain:

This is part of an effort to hopefully make `ralphbot`'s codebase easier to add further unit testing.
