### PR TITLE
fix: updates invalid guidefetch message

### DIFF
--- a/src/internal/command/guidefetch/guidefetch.go
+++ b/src/internal/command/guidefetch/guidefetch.go
@@ -73,7 +73,7 @@ func getInteractionResponse(i *discordgo.InteractionCreate) *discordgo.Interacti
 	}
 
 	response.Data.Content = "Oops, your command didn't return a guide message!\n"
-	log.Printf("fetch-guide has ran into `default` in switch statement! Value: %v", i.ApplicationCommandData().Options[0].Name)
+	log.Printf("fetch-guide was unablet to source guide: %v", i.ApplicationCommandData().Options[0].Name)
 	return response
 }
 


### PR DESCRIPTION
# Purpose :dart:

This change updates the log message for when `guidefetch` is unable to source a guide from a given input. Instead of referring to a "switch statement", the message is now a generic "couldn't source guide _x_".

# Context :brain:

Follow up to changes in https://github.com/therealvio-org/ralphbot/pull/395
