### PR TITLE
test: Adds tests for `guidefetch` and `dadjoke` commands, and CheckGuildId

### DIFF
--- a/src/internal/command/dadjoke/dadjoke.go
+++ b/src/internal/command/dadjoke/dadjoke.go
@@ -27,7 +27,7 @@ func getJokes(b []byte) ([]string, error) {
 	return jokeArray.Jokes, nil
 }
 
-func dadJoke(j []string) string {
+func selectDadJoke(j []string) string {
 	selectedDadJoke := j[rand.Intn(len(j))]
 	result := string(selectedDadJoke)
 	return result
@@ -54,7 +54,7 @@ func GetCommandHandlers() (map[string]func(s *discordgo.Session, i *discordgo.In
 			err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
 				Data: &discordgo.InteractionResponseData{
-					Content: dadJoke(jokes),
+					Content: selectDadJoke(jokes),
 				},
 			})
 			if err != nil {

--- a/src/internal/command/dadjoke/dadjoke.go
+++ b/src/internal/command/dadjoke/dadjoke.go
@@ -28,7 +28,7 @@ func getJokes(b []byte) []string {
 
 }
 
-func dadJoke(i *discordgo.InteractionCreate, j []string) string {
+func dadJoke(j []string) string {
 	selectedDadJoke := j[rand.Intn(len(j))]
 	result := string(selectedDadJoke)
 	return result
@@ -52,7 +52,7 @@ func GetCommandHandlers() (map[string]func(s *discordgo.Session, i *discordgo.In
 			err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
 				Data: &discordgo.InteractionResponseData{
-					Content: dadJoke(i, jokes),
+					Content: dadJoke(jokes),
 				},
 			})
 			if err != nil {

--- a/src/internal/command/dadjoke/dadjoke.go
+++ b/src/internal/command/dadjoke/dadjoke.go
@@ -3,6 +3,7 @@ package dadjoke
 import (
 	_ "embed"
 	"encoding/json"
+	"fmt"
 	"log"
 	"math/rand"
 
@@ -16,16 +17,14 @@ type JokeStruct struct {
 	Jokes []string `json:"jokes"`
 }
 
-func getJokes(b []byte) []string {
+func getJokes(b []byte) ([]string, error) {
 
 	var jokeArray JokeStruct
 	err := json.Unmarshal(b, &jokeArray)
 	if err != nil {
-		log.Printf("Unable to Unmarshal : %v", err)
+		return nil, fmt.Errorf("unable to unmarshal json: %v", err)
 	}
-
-	return jokeArray.Jokes
-
+	return jokeArray.Jokes, nil
 }
 
 func dadJoke(j []string) string {
@@ -45,7 +44,10 @@ func GetCommands() []*discordgo.ApplicationCommand {
 }
 
 func GetCommandHandlers() (map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate), error) {
-	jokes := getJokes(jokesFile)
+	jokes, err := getJokes(jokesFile)
+	if err != nil {
+		return nil, fmt.Errorf("unable to execute getJokes: %v", err)
+	}
 
 	return map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){
 		"dad-joke": func(s *discordgo.Session, i *discordgo.InteractionCreate) {

--- a/src/internal/command/dadjoke/dadjoke_test.go
+++ b/src/internal/command/dadjoke/dadjoke_test.go
@@ -1,0 +1,81 @@
+package dadjoke
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetJokes(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		expect struct {
+			result struct {
+				slice        []string
+				errorMessage string
+			}
+		}
+	}{
+		{
+			name: "with a json array length of 3, getJokes returns a slice with length of 3",
+			input: `{
+						"jokes": [
+							"the joke is this test suite",
+							"not really",
+							"unless?"
+						]
+					}`,
+			expect: struct {
+				result struct {
+					slice        []string
+					errorMessage string
+				}
+			}{
+				result: struct {
+					slice        []string
+					errorMessage string
+				}{
+					slice: []string{"the joke is this test suite", "not really", "unless?"},
+				},
+			},
+		},
+		{
+			name: "when a bad json input is provided, getJokes returns a slice with length of 0, and an error",
+			input: `{
+				"bad-json": {
+					notAValidKey: true
+				}
+			}`,
+			expect: struct {
+				result struct {
+					slice        []string
+					errorMessage string
+				}
+			}{
+				result: struct {
+					slice        []string
+					errorMessage string
+				}{
+					errorMessage: "unable to unmarshal json: invalid character 'n' looking for beginning of object key string",
+				},
+			},
+		},
+	}
+
+	for _, test := range cases {
+		result, err := getJokes([]byte(test.input))
+
+		// assertions for scenarios that don't produce errors
+		if err == nil {
+			assert.Len(t, result, len(test.expect.result.slice))
+			assert.Equal(t, test.expect.result.slice, result)
+		}
+
+		// assertions for scenarios that produce errors
+		if err != nil {
+			assert.EqualError(t, err, test.expect.result.errorMessage)
+			assert.Equal(t, test.expect.result.slice, result)
+		}
+	}
+}

--- a/src/internal/command/dadjoke/dadjoke_test.go
+++ b/src/internal/command/dadjoke/dadjoke_test.go
@@ -1,10 +1,18 @@
 package dadjoke
 
 import (
+	"io"
+	"log"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMain(m *testing.M) {
+	log.SetOutput(io.Discard)
+	os.Exit(m.Run())
+}
 
 func TestGetJokes(t *testing.T) {
 	cases := []struct {

--- a/src/internal/command/dadjoke/dadjoke_test.go
+++ b/src/internal/command/dadjoke/dadjoke_test.go
@@ -79,3 +79,31 @@ func TestGetJokes(t *testing.T) {
 		}
 	}
 }
+
+func TestSelectDadJoke(t *testing.T) {
+	cases := []struct {
+		name  string
+		input []string
+	}{
+		{
+			name: "given 3 jokes, selectDadJoke will randomly pick a joke",
+			input: []string{
+				"option 1",
+				"option 2",
+				"option 3",
+			},
+		},
+	}
+
+	for _, test := range cases {
+		result := selectDadJoke(test.input)
+
+		// testing for probability i.e. does our result show up at least once? This is more of a "transparency" test
+		var resultTally []string
+		for i := 0; i < 1000; i++ {
+			resultTally = append(resultTally, selectDadJoke(test.input))
+		}
+
+		assert.Contains(t, resultTally, result)
+	}
+}

--- a/src/internal/command/guidefetch/guide.go
+++ b/src/internal/command/guidefetch/guide.go
@@ -73,7 +73,7 @@ var (
 		GDriveUrl:      "https://drive.google.com/drive/folders/1d_WEa84KuX1_9hPTwgFhl651IwywHeOg?usp=sharing",
 	}
 
-	guides = []guide{
+	Guides = []guide{
 		*crypt,
 		*garden,
 		*kingsfall,

--- a/src/internal/command/guidefetch/guide.go
+++ b/src/internal/command/guidefetch/guide.go
@@ -4,8 +4,8 @@ type guide struct {
 	Name           string
 	SubCommandName string
 	Description    string
-	GDriveUrl      string
-	GHUrl          string
+	GDriveLink     string
+	GHLink         string
 }
 
 var (
@@ -13,64 +13,64 @@ var (
 		Name:           "Deep Stone Crypt",
 		SubCommandName: "raid-crypt",
 		Description:    "Deep Stone Crypt Raid",
-		GDriveUrl:      "https://drive.google.com/drive/folders/1YKU4_-hInHQ3rVEAvqIjdJaT25oQvmYc?usp=sharing",
+		GDriveLink:     "https://drive.google.com/drive/folders/1YKU4_-hInHQ3rVEAvqIjdJaT25oQvmYc?usp=sharing",
 	}
 
 	garden = &guide{
 		Name:           "Garden of Salvation",
 		SubCommandName: "raid-garden",
 		Description:    "Garden of Salvation Raid",
-		GDriveUrl:      "https://drive.google.com/drive/folders/1pPdtAptJMaaDYRv2i-8bfaL6l3I0WTsT?usp=sharing",
+		GDriveLink:     "https://drive.google.com/drive/folders/1pPdtAptJMaaDYRv2i-8bfaL6l3I0WTsT?usp=sharing",
 	}
 
 	kingsfall = &guide{
 		Name:           "King's Fall",
 		SubCommandName: "raid-kingsfall",
 		Description:    "King's Fall Raid",
-		GDriveUrl:      "https://drive.google.com/drive/folders/1tsOVCy2SwP0rLUDQUJaDIFh5y-O0DoKn",
+		GDriveLink:     "https://drive.google.com/drive/folders/1tsOVCy2SwP0rLUDQUJaDIFh5y-O0DoKn",
 	}
 
 	pit = &guide{
 		Name:           "Pit of Heresy",
 		SubCommandName: "dungeon-pit",
 		Description:    "Pit of Heresy Dungeon",
-		GDriveUrl:      "https://drive.google.com/drive/folders/17lB7m9KQMwzBb6UHfoBt9ZEA82haD2Fd?usp=sharing",
+		GDriveLink:     "https://drive.google.com/drive/folders/17lB7m9KQMwzBb6UHfoBt9ZEA82haD2Fd?usp=sharing",
 	}
 
 	ron = &guide{
 		Name:           "The Root of Nightmares",
 		SubCommandName: "raid-tron",
 		Description:    "The Root of Nightmares Raid",
-		GDriveUrl:      "https://drive.google.com/drive/folders/1eR50Jt36GBegMALRkT-tmnH6Nnjc4Pqj?usp=share_link",
+		GDriveLink:     "https://drive.google.com/drive/folders/1eR50Jt36GBegMALRkT-tmnH6Nnjc4Pqj?usp=share_link",
 	}
 
 	spire = &guide{
 		Name:           "Spire of the Watcher",
 		SubCommandName: "dungeon-spire",
 		Description:    "Spire of the Watcher Dungeon",
-		GDriveUrl:      "https://drive.google.com/drive/folders/1Xu_8NfiPFnknocqdR8p9adWPF-qiHmxo?usp=share_link",
+		GDriveLink:     "https://drive.google.com/drive/folders/1Xu_8NfiPFnknocqdR8p9adWPF-qiHmxo?usp=share_link",
 	}
 
 	vault = &guide{
 		Name:           "Vault of Glass",
 		SubCommandName: "raid-vault",
 		Description:    "Vault of Glass Raid",
-		GDriveUrl:      "https://drive.google.com/drive/folders/1HLx6nVIji_3OcwnzaLeSoksspa4pfdjD?usp=sharing",
+		GDriveLink:     "https://drive.google.com/drive/folders/1HLx6nVIji_3OcwnzaLeSoksspa4pfdjD?usp=sharing",
 	}
 
 	vow = &guide{
 		Name:           "Vow of the Disciple",
 		SubCommandName: "raid-vow",
 		Description:    "Vow of the Disciple Raid",
-		GDriveUrl:      "https://drive.google.com/drive/folders/1ZAPIXYlSs7yTQEdznQAqz2rOnnvpzwr7?usp=sharing",
-		GHUrl:          "https://github.com/therealvio/destiny-guides/tree/main/raids/vow-of-the-disciple",
+		GDriveLink:     "https://drive.google.com/drive/folders/1ZAPIXYlSs7yTQEdznQAqz2rOnnvpzwr7?usp=sharing",
+		GHLink:         "https://github.com/therealvio/destiny-guides/tree/main/raids/vow-of-the-disciple",
 	}
 
 	wish = &guide{
 		Name:           "Last Wish",
 		SubCommandName: "raid-lastwish",
 		Description:    "Last Wish Raid",
-		GDriveUrl:      "https://drive.google.com/drive/folders/1d_WEa84KuX1_9hPTwgFhl651IwywHeOg?usp=sharing",
+		GDriveLink:     "https://drive.google.com/drive/folders/1d_WEa84KuX1_9hPTwgFhl651IwywHeOg?usp=sharing",
 	}
 
 	Guides = []guide{

--- a/src/internal/command/guidefetch/guidefetch.go
+++ b/src/internal/command/guidefetch/guidefetch.go
@@ -8,7 +8,7 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-func generateCommandOptions(g []guide) ([]*discordgo.ApplicationCommandOption, error) {
+func GenerateCommandOptions(g []guide) ([]*discordgo.ApplicationCommandOption, error) {
 	var subCommands []*discordgo.ApplicationCommandOption
 
 	if g == nil {
@@ -26,19 +26,15 @@ func generateCommandOptions(g []guide) ([]*discordgo.ApplicationCommandOption, e
 	return subCommands, nil
 }
 
-func GetCommands() ([]*discordgo.ApplicationCommand, error) {
-	commandOptions, err := generateCommandOptions(guides)
-	if err != nil {
-		return nil, fmt.Errorf("unable to generated command options: %v", err)
-	}
+func GetCommands(co []*discordgo.ApplicationCommandOption) []*discordgo.ApplicationCommand {
 	return []*discordgo.ApplicationCommand{
 		//https://discord.com/developers/docs/interactions/application-commands#slash-commands
 		{
 			Name:        "fetch-guide",
 			Description: "Provides a link to materials for a given Destiny activity",
-			Options:     commandOptions,
+			Options:     co,
 		},
-	}, nil
+	}
 }
 
 func GetCommandHandlers() map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate) {
@@ -61,7 +57,7 @@ func getInteractionResponse(i *discordgo.InteractionCreate) *discordgo.Interacti
 		},
 	}
 
-	for _, g := range guides {
+	for _, g := range Guides {
 		if i.ApplicationCommandData().Options[0].Name == g.SubCommandName {
 			if g.GHUrl != "" {
 				response.Data.Content = guideGithub(i, g.Name, g.GHUrl, g.GDriveUrl)

--- a/src/internal/command/guidefetch/guidefetch.go
+++ b/src/internal/command/guidefetch/guidefetch.go
@@ -40,8 +40,8 @@ func GetCommands(co []*discordgo.ApplicationCommandOption) []*discordgo.Applicat
 func GetCommandHandlers() map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	return map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){
 		"fetch-guide": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
-			response := getInteractionResponse(i)
-			err := s.InteractionRespond(i.Interaction, response)
+			resp := getInteractionResponse(i)
+			err := s.InteractionRespond(i.Interaction, resp)
 			if err != nil {
 				log.Printf("Failed to respond to interaction: %v", err)
 			}
@@ -50,6 +50,11 @@ func GetCommandHandlers() map[string]func(s *discordgo.Session, i *discordgo.Int
 }
 
 func getInteractionResponse(i *discordgo.InteractionCreate) *discordgo.InteractionResponse {
+	if i.Type != discordgo.InteractionApplicationCommand {
+		log.Printf("fetchguide - interaction type does not match: discordgo.InteractionApplicationCommand - Type: %v Data:%v", i.Type, i.Data)
+		return nil
+	}
+
 	response := &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
@@ -59,31 +64,21 @@ func getInteractionResponse(i *discordgo.InteractionCreate) *discordgo.Interacti
 
 	for _, g := range Guides {
 		if i.ApplicationCommandData().Options[0].Name == g.SubCommandName {
-			if g.GHLink != "" {
-				response.Data.Content = guideGithub(i, g.Name, g.GHLink, g.GDriveLink)
-				return response
-			}
-			response.Data.Content = guideMessage(i, g.Name, g.GDriveLink)
+			response.Data.Content = guideMessage(i, &g)
 			return response
 		}
 	}
 
 	response.Data.Content = "Oops, your command didn't return a guide message!\n"
-	log.Printf("fetch-guide was unablet to source guide: %v", i.ApplicationCommandData().Options[0].Name)
+	log.Printf("fetch-guide was unable to source guide: %v", i.ApplicationCommandData().Options[0].Name)
 	return response
 }
 
-func guideMessage(i *discordgo.InteractionCreate, activity string, link string) string {
-	result := fmt.Sprintf("%s, here is your requested **%s** supplementary material!\n\n[Google Drive Link](%s)", i.Member.Mention(), activity, link)
-	return result
-}
-
-/**
-Testing Github links in tandem with Google Drive links
-Arrow brackets are used to escape the github link to prevent previews
-*/
-
-func guideGithub(i *discordgo.InteractionCreate, activity string, ghubLink string, gdriveLink string) string {
-	result := fmt.Sprintf("%s, here is your requested **%s** supplementary material!\n\n[Github Link](<%s>)\n[Google Drive Link](%s)", i.Member.Mention(), activity, ghubLink, gdriveLink)
+func guideMessage(i *discordgo.InteractionCreate, g *guide) string {
+	if g.GHLink != "" {
+		result := fmt.Sprintf("%s, here is your requested **%s** supplementary material!\n\n[Github Link](<%s>)\n[Google Drive Link](%s)", i.Member.Mention(), g.Name, g.GHLink, g.GDriveLink)
+		return result
+	}
+	result := fmt.Sprintf("%s, here is your requested **%s** supplementary material!\n\n[Google Drive Link](%s)", i.Member.Mention(), g.Name, g.GDriveLink)
 	return result
 }

--- a/src/internal/command/guidefetch/guidefetch.go
+++ b/src/internal/command/guidefetch/guidefetch.go
@@ -59,11 +59,11 @@ func getInteractionResponse(i *discordgo.InteractionCreate) *discordgo.Interacti
 
 	for _, g := range Guides {
 		if i.ApplicationCommandData().Options[0].Name == g.SubCommandName {
-			if g.GHUrl != "" {
-				response.Data.Content = guideGithub(i, g.Name, g.GHUrl, g.GDriveUrl)
+			if g.GHLink != "" {
+				response.Data.Content = guideGithub(i, g.Name, g.GHLink, g.GDriveLink)
 				return response
 			}
-			response.Data.Content = guideMessage(i, g.Name, g.GDriveUrl)
+			response.Data.Content = guideMessage(i, g.Name, g.GDriveLink)
 			return response
 		}
 	}

--- a/src/internal/command/guidefetch/guidefetch_test.go
+++ b/src/internal/command/guidefetch/guidefetch_test.go
@@ -2,11 +2,19 @@ package guidefetch
 
 import (
 	"fmt"
+	"io"
+	"log"
+	"os"
 	"testing"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMain(m *testing.M) {
+	log.SetOutput(io.Discard)
+	os.Exit(m.Run())
+}
 
 func TestGenerateCommandOptions(t *testing.T) {
 	backrooms := &guide{

--- a/src/internal/command/guidefetch/guidefetch_test.go
+++ b/src/internal/command/guidefetch/guidefetch_test.go
@@ -13,15 +13,15 @@ func TestGenerateCommandOptions(t *testing.T) {
 		Name:           "The Backrooms",
 		SubCommandName: "raid-backrooms",
 		Description:    "The Backrooms Raid",
-		GDriveUrl:      "https://drive.google.com/drive/folders/123456abcdef?usp=sharing",
-		GHUrl:          "https://github.com/butterdog/destiny-guides/tree/main/raids/the-backrooms",
+		GDriveLink:     "https://drive.google.com/drive/folders/123456abcdef?usp=sharing",
+		GHLink:         "https://github.com/butterdog/destiny-guides/tree/main/raids/the-backrooms",
 	}
 
 	wax := &guide{
 		Name:           "Wax Museum",
 		SubCommandName: "raid-wax",
 		Description:    "The Wax Museum Raid",
-		GDriveUrl:      "https://drive.google.com/drive/folders/1d_WEa84KuX1_9hPTwgFhl651IwywHeOg?usp=sharing",
+		GDriveLink:     "https://drive.google.com/drive/folders/1d_WEa84KuX1_9hPTwgFhl651IwywHeOg?usp=sharing",
 	}
 
 	cases := []struct {

--- a/src/internal/command/guidefetch/guidefetch_test.go
+++ b/src/internal/command/guidefetch/guidefetch_test.go
@@ -68,9 +68,63 @@ func TestGenerateCommandOptions(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		result, err := generateCommandOptions(test.input)
+		result, err := GenerateCommandOptions(test.input)
 		assert.NoError(t, err)
 		assert.Len(t, result, len(test.expected))
 		assert.ElementsMatch(t, test.expected, result)
+	}
+}
+
+func TestGetCommands(t *testing.T) {
+	backrooms := &discordgo.ApplicationCommandOption{
+		Name:        "The Backrooms",
+		Description: "The Backrooms Raid",
+		Type:        discordgo.ApplicationCommandOptionSubCommand,
+	}
+
+	wax := &discordgo.ApplicationCommandOption{
+		Name:        "The Wax Museum",
+		Description: "The Wax Museum Raid",
+		Type:        discordgo.ApplicationCommandOptionSubCommand,
+	}
+
+	cases := []struct {
+		name   string
+		input  []*discordgo.ApplicationCommandOption
+		expect []*discordgo.ApplicationCommand
+	}{
+		{
+			name: "when one command option is provided, the command only has one option",
+			input: []*discordgo.ApplicationCommandOption{
+				backrooms,
+			},
+			expect: []*discordgo.ApplicationCommand{{
+				Name:        "fetch-guide",
+				Description: "Provides a link to materials for a given Destiny activity",
+				Options: []*discordgo.ApplicationCommandOption{
+					backrooms,
+				},
+			}},
+		},
+		{
+			name: "when two command options are provided, the command has two options",
+			input: []*discordgo.ApplicationCommandOption{
+				backrooms,
+				wax,
+			},
+			expect: []*discordgo.ApplicationCommand{{
+				Name:        "fetch-guide",
+				Description: "Provides a link to materials for a given Destiny activity",
+				Options: []*discordgo.ApplicationCommandOption{
+					backrooms,
+					wax,
+				},
+			}},
+		},
+	}
+
+	for _, test := range cases {
+		result := GetCommands(test.input)
+		assert.Equal(t, test.expect, result)
 	}
 }

--- a/src/internal/command/guidefetch/guidefetch_test.go
+++ b/src/internal/command/guidefetch/guidefetch_test.go
@@ -1,6 +1,7 @@
 package guidefetch
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/bwmarrin/discordgo"
@@ -127,5 +128,91 @@ func TestGetCommands(t *testing.T) {
 		result := GetCommands(test.input)
 		assert.Equal(t, test.expect, result)
 		assert.IsType(t, test.expect, result)
+	}
+}
+
+func TestGuideMessage(t *testing.T) {
+	sampleInteractionCreateBigBosso := discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		Member: &discordgo.Member{
+			User: &discordgo.User{
+				ID: "bigbosso123",
+			},
+		},
+	}}
+
+	backroomsGDriveUrl := "not-a-real-url-lmao.com/backrooms"
+
+	casesGuideMessage := []struct {
+		name  string
+		input struct {
+			interaction *discordgo.InteractionCreate
+			activity    string
+			gDriveLink  string
+		}
+		expect string
+	}{
+		{
+			name: "when user bigbosso requests a backrooms guide, a guide message is returned with a mention for bigbosso",
+			input: struct {
+				interaction *discordgo.InteractionCreate
+				activity    string
+				gDriveLink  string
+			}{
+				interaction: &sampleInteractionCreateBigBosso,
+				activity:    "backrooms",
+				gDriveLink:  backroomsGDriveUrl,
+			},
+			expect: fmt.Sprintf("<@!%s>, here is your requested **%s** supplementary material!\n\n[Google Drive Link](%s)", sampleInteractionCreateBigBosso.Interaction.Member.User.ID, "backrooms", backroomsGDriveUrl),
+		},
+	}
+
+	for _, test := range casesGuideMessage {
+		result := guideMessage(test.input.interaction, test.input.activity, test.input.gDriveLink)
+		assert.Equal(t, test.expect, result)
+	}
+}
+
+func TestGuideGithubMessage(t *testing.T) {
+	sampleInteractionCreateBigBosso := discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		Member: &discordgo.Member{
+			User: &discordgo.User{
+				ID: "bigbosso123",
+			},
+		},
+	}}
+
+	backroomsGHubUrl := "also-not-a-real-url-lmao.com/backrooms"
+	backroomsGDriveUrl := "not-a-real-url-lmao.com/backrooms"
+
+	casesGuideGithubMessage := []struct {
+		name  string
+		input struct {
+			interaction *discordgo.InteractionCreate
+			activity    string
+			gDriveLink  string
+			gHubLink    string
+		}
+		expect string
+	}{
+		{
+			name: "when user bigbosso requests a backrooms guide, a guide message is returned with a mention for bigbosso",
+			input: struct {
+				interaction *discordgo.InteractionCreate
+				activity    string
+				gDriveLink  string
+				gHubLink    string
+			}{
+				interaction: &sampleInteractionCreateBigBosso,
+				activity:    "backrooms",
+				gDriveLink:  backroomsGDriveUrl,
+				gHubLink:    backroomsGHubUrl,
+			},
+			expect: fmt.Sprintf("<@!%s>, here is your requested **%s** supplementary material!\n\n[Github Link](<%s>)\n[Google Drive Link](%s)", sampleInteractionCreateBigBosso.Interaction.Member.User.ID, "backrooms", backroomsGHubUrl, backroomsGDriveUrl),
+		},
+	}
+
+	for _, test := range casesGuideGithubMessage {
+		result := guideGithub(test.input.interaction, test.input.activity, test.input.gHubLink, test.input.gDriveLink)
+		assert.Equal(t, test.expect, result)
 	}
 }

--- a/src/internal/command/guidefetch/guidefetch_test.go
+++ b/src/internal/command/guidefetch/guidefetch_test.go
@@ -126,5 +126,6 @@ func TestGetCommands(t *testing.T) {
 	for _, test := range cases {
 		result := GetCommands(test.input)
 		assert.Equal(t, test.expect, result)
+		assert.IsType(t, test.expect, result)
 	}
 }

--- a/src/internal/command/linkdump/linkdump_test.go
+++ b/src/internal/command/linkdump/linkdump_test.go
@@ -2,10 +2,18 @@ package linkdump
 
 import (
 	"fmt"
+	"io"
+	"log"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMain(m *testing.M) {
+	log.SetOutput(io.Discard)
+	os.Exit(m.Run())
+}
 
 func TestGetLinks(t *testing.T) {
 

--- a/src/internal/discord/command.go
+++ b/src/internal/discord/command.go
@@ -9,11 +9,6 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-type DiscordSource interface {
-	AddHandler(handler interface{})
-	ApplicationCommandCreate(appID string, guildID string, cmd *discordgo.ApplicationCommand, options ...discordgo.RequestOption) (ccmd *discordgo.ApplicationCommand, err error)
-}
-
 // Registers commands for `ralphbot` service.
 // If `GUILD_ID` is passed, then the command is set as a guild command, and will not be registered globally. However, it will be immediately registered exclusively
 // to the Discord server (guild). If `GUILD_ID` is not passed, then the command is registered globally.

--- a/src/internal/discord/guild.go
+++ b/src/internal/discord/guild.go
@@ -2,7 +2,13 @@ package discord
 
 import (
 	"log"
+
+	"github.com/bwmarrin/discordgo"
 )
+
+type DiscordAPI interface {
+	Guild(guildID string, options ...discordgo.RequestOption) (st *discordgo.Guild, err error)
+}
 
 // If GUILD_ID was passed, it checks to see if the GUILD_ID environment variable matches the discord server's (guild) id that
 // `ralphbot` is connected to.
@@ -10,12 +16,13 @@ import (
 // i.e. immediate registration for the server, vs a live command
 //
 // The intention for this is to help facilitate local testing on a private server. In production, commands should be `global`.
-func CheckGuildId(ds *DiscordSession, id string) {
+// Return `true` if `id` matches guildId, otherwise return `false`
+func CheckGuildId(dAPI DiscordAPI, id string) bool {
 	doFail := false
 	if id != "" {
 		log.Printf("Checking for GuildID variable validity against current server (if it matches, we're okay)...")
 
-		g, err := ds.Guild(id)
+		g, err := dAPI.Guild(id)
 		if err != nil {
 			log.Fatalf("Cannot retrieve Guild Id from server: %v", err)
 		}
@@ -23,6 +30,7 @@ func CheckGuildId(ds *DiscordSession, id string) {
 		if id == g.ID {
 			log.Printf("GuildID is valid...")
 			log.Printf("GuildID is defined - ralphbot is running in development mode, Guild commands are available...")
+			return true
 		} else {
 			log.Printf("GuildID is invalid...")
 			doFail = true
@@ -33,5 +41,8 @@ func CheckGuildId(ds *DiscordSession, id string) {
 
 	if doFail {
 		log.Printf("GuildID is undefined - ralphbot is running in production mode, only Global commands are available...")
+		return false
 	}
+
+	return false
 }

--- a/src/internal/discord/guild.go
+++ b/src/internal/discord/guild.go
@@ -18,7 +18,6 @@ type DiscordAPI interface {
 // The intention for this is to help facilitate local testing on a private server. In production, commands should be `global`.
 // Return `true` if `id` matches guildId, otherwise return `false`
 func CheckGuildId(dAPI DiscordAPI, id string) bool {
-	doFail := false
 	if id != "" {
 		log.Printf("Checking for GuildID variable validity against current server (if it matches, we're okay)...")
 
@@ -33,16 +32,9 @@ func CheckGuildId(dAPI DiscordAPI, id string) bool {
 			return true
 		} else {
 			log.Printf("GuildID is invalid...")
-			doFail = true
 		}
-	} else {
-		doFail = true
 	}
 
-	if doFail {
-		log.Printf("GuildID is undefined - ralphbot is running in production mode, only Global commands are available...")
-		return false
-	}
-
+	log.Printf("GuildID is undefined - ralphbot is running in production mode, only Global commands are available...")
 	return false
 }

--- a/src/internal/discord/guild_test.go
+++ b/src/internal/discord/guild_test.go
@@ -1,0 +1,84 @@
+package discord
+
+import (
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/stretchr/testify/assert"
+)
+
+// NOTE: mockGuild is named after the method we're mocking, not a particular package
+type mockGuild func(guildID string, options ...discordgo.RequestOption) (st *discordgo.Guild, err error)
+
+func (m mockGuild) Guild(guildID string, options ...discordgo.RequestOption) (st *discordgo.Guild, err error) {
+	return m(guildID, options...)
+}
+
+func TestCheckGuildId(t *testing.T) {
+	testGuildId := "123456789"
+	cases := []struct {
+		name  string
+		input struct {
+			api func(t *testing.T) mockGuild
+			id  string
+		}
+		expect bool
+	}{
+		{
+			name: "when no guildID is provided, return false",
+			input: struct {
+				api func(t *testing.T) mockGuild
+				id  string
+			}{
+				api: func(t *testing.T) mockGuild {
+					return mockGuild(func(guildID string, options ...discordgo.RequestOption) (st *discordgo.Guild, err error) {
+						return &discordgo.Guild{
+							ID: testGuildId,
+						}, nil
+					})
+				},
+				id: "",
+			},
+			expect: false,
+		},
+		{
+			name: "when guildID is provided, and matches the session guildID, return true",
+			input: struct {
+				api func(t *testing.T) mockGuild
+				id  string
+			}{
+				api: func(t *testing.T) mockGuild {
+					return mockGuild(func(guildID string, options ...discordgo.RequestOption) (st *discordgo.Guild, err error) {
+						return &discordgo.Guild{
+							ID: testGuildId,
+						}, nil
+					})
+				},
+				id: testGuildId,
+			},
+			expect: true,
+		},
+		{
+			name: "when guildID is provided, and does not match the session guildID, return false",
+			input: struct {
+				api func(t *testing.T) mockGuild
+				id  string
+			}{
+				api: func(t *testing.T) mockGuild {
+					return mockGuild(func(guildID string, options ...discordgo.RequestOption) (st *discordgo.Guild, err error) {
+						return &discordgo.Guild{
+							ID: testGuildId,
+						}, nil
+					})
+				},
+				id: "987654321",
+			},
+			expect: false,
+		},
+	}
+
+	for _, test := range cases {
+		result := CheckGuildId(test.input.api(t), test.input.id)
+		assert.Equal(t, test.expect, result)
+	}
+}

--- a/src/internal/discord/guild_test.go
+++ b/src/internal/discord/guild_test.go
@@ -1,6 +1,9 @@
 package discord
 
 import (
+	"io"
+	"log"
+	"os"
 	"testing"
 
 	"github.com/bwmarrin/discordgo"
@@ -12,6 +15,11 @@ type mockGuild func(guildID string, options ...discordgo.RequestOption) (st *dis
 
 func (m mockGuild) Guild(guildID string, options ...discordgo.RequestOption) (st *discordgo.Guild, err error) {
 	return m(guildID, options...)
+}
+
+func TestMain(m *testing.M) {
+	log.SetOutput(io.Discard)
+	os.Exit(m.Run())
 }
 
 func TestCheckGuildId(t *testing.T) {

--- a/src/internal/discord/service.go
+++ b/src/internal/discord/service.go
@@ -50,12 +50,11 @@ func StartBotService(ds *DiscordSession, env *config.EnvConfig) error {
 	defer ds.Close()
 
 	// guide fetch
-	commandGF, err := guidefetch.GetCommands()
+	commandOptionsGF, err := guidefetch.GenerateCommandOptions(guidefetch.Guides)
 	if err != nil {
-		err = fmt.Errorf("unable to prepare command for %v error: %v", "guidefetch", err)
-		return err
+		return fmt.Errorf("unable to generated command options for %v error: %v", "guidefetch", err)
 	}
-	_, err = registerCommand(ds, env.GuildID, commandGF, guidefetch.GetCommandHandlers())
+	_, err = registerCommand(ds, env.GuildID, guidefetch.GetCommands(commandOptionsGF), guidefetch.GetCommandHandlers())
 	if err != nil {
 		err = fmt.Errorf("unable to register command %v error: %v", "guidefetch", err)
 		return err

--- a/src/internal/discord/service_test.go
+++ b/src/internal/discord/service_test.go
@@ -10,13 +10,10 @@ import (
 // This is more of a regression test. NewDiscord() shouldn't be doing more than setting up a new session
 // additionally, if Discord.New() requires extra parameters, or returns more than just the session, this test will catch it outside of the assertions
 func TestNewDiscord(t *testing.T) {
-	// arrange
 	dgs := &discordgo.Session{}
 
-	// act
 	ds, err := NewDiscord("mockSecret123")
 
-	// assert
 	assert.NoError(t, err)
 	assert.IsType(t, dgs, ds.Session)
 }


### PR DESCRIPTION
# Purpose :dart:

These changes feature new tests, as well as refactoring to better support tests for the following:
- `guidefetch` bot command
- `dadjoke` bot command
- `CheckGuildId` function

The inclusion of these tests will enable greater confidence in the continuing functioning of `ralphbot`'s code following updates concerning `golang` dependencies merged by `renovate`.

# Context :brain:

Part of a long-term effort to have `ralphbot`'s dependencies 100% automatically updated by `renovate`. Although we are not finished, this should cover the bulk of concerns with dependency upgrades 😌
