### PR TITLE
chore: Enable automerge of golang deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,7 +47,7 @@
     },
     {
       "groupName": "golang",
-      "automerge": false,
+      "automerge": true,
       "matchDatasources": ["golang-version"],
       "matchManagers": ["asdf", "dockerfile", "gomod"],
       "rangeStrategy": "bump"


### PR DESCRIPTION
# Purpose :dart:

These changes enable `renovate`'s automerge capabilities for `golang` dependencies. It is important to keep dependencies up to date in order to ensure ongoing functionality of services interacting with third party APIs.

# Context :brain:

In PR #411, a bulk of tests were added that increase confidence in code functionality when running tests.

These tests were critical in determining that dependency upgrades would not cause issues with `ralphbot`'s operations. At this stage, new cases would need to be added in future scenarios - for now, the coverage is sufficient.
