### PR TITLE
feat: Coinflip can settle binary choices

### DIFF
--- a/src/internal/command/coinflip/coinflip.go
+++ b/src/internal/command/coinflip/coinflip.go
@@ -55,7 +55,10 @@ func makePhrase(side string, phrase string) string {
 	if err != nil {
 		log.Printf("Failed to parse phrase template: %v", err)
 	}
-	template.Execute(buf, c)
+	err = template.Execute(buf, c)
+	if err != nil {
+		log.Printf("Failed to execute phrase template: %v", err)
+	}
 
 	return buf.String()
 }

--- a/src/internal/command/coinflip/coinflip.go
+++ b/src/internal/command/coinflip/coinflip.go
@@ -1,0 +1,46 @@
+package coinflip
+
+import (
+	"log"
+	"math/rand"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+var (
+	sides = []string{"heads", "tails"}
+)
+
+func coinFlip() string {
+	rand.NewSource(time.Now().UnixNano())
+	selectedSide := sides[rand.Intn(len(sides))]
+	return selectedSide
+}
+
+func GetCommands() []*discordgo.ApplicationCommand {
+	return []*discordgo.ApplicationCommand{
+		{
+			Name:        "coin-flip",
+			Description: "Let ralphbot choose for you",
+		},
+	}
+}
+
+func GetCommandHandlers() (map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate), error) {
+	side := coinFlip()
+
+	return map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){
+		"coin-flip": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Content: side,
+				},
+			})
+			if err != nil {
+				log.Printf("Failed to respond to interaction: %v", err)
+			}
+		},
+	}, nil
+}

--- a/src/internal/command/coinflip/coinflip.go
+++ b/src/internal/command/coinflip/coinflip.go
@@ -32,6 +32,7 @@ func selectPhrase(phrases []string) string {
 }
 
 func makePhrase(side string, phrase string) string {
+	// coin sides are always strings, though we need to use a struct to satisfy template execution
 	type coin struct {
 		Side string
 	}
@@ -39,7 +40,10 @@ func makePhrase(side string, phrase string) string {
 	c := &coin{}
 	c.Side = side
 	buf := new(bytes.Buffer)
-	template, _ := template.New("phrase").Parse(phrase)
+	template, err := template.New("phrase").Parse(phrase)
+	if err != nil {
+		log.Printf("Failed to parse phrase template: %v", err)
+	}
 	template.Execute(buf, c)
 
 	return buf.String()

--- a/src/internal/command/coinflip/coinflip.go
+++ b/src/internal/command/coinflip/coinflip.go
@@ -21,7 +21,6 @@ var (
 )
 
 func coinFlip() string {
-	rand.NewSource(time.Now().UnixNano())
 	selectedSide := sides[rand.Intn(len(sides))]
 	return selectedSide
 }
@@ -56,16 +55,12 @@ func GetCommands() []*discordgo.ApplicationCommand {
 }
 
 func GetCommandHandlers() (map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate), error) {
-	side := coinFlip()
-	selectedPhrase := selectPhrase(phrases)
-	constructedPhrase := makePhrase(side, selectedPhrase)
-
 	return map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){
 		"coin-flip": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
 				Data: &discordgo.InteractionResponseData{
-					Content: constructedPhrase,
+					Content: makePhrase(coinFlip(), selectPhrase(phrases)),
 				},
 			})
 			if err != nil {

--- a/src/internal/command/coinflip/coinflip.go
+++ b/src/internal/command/coinflip/coinflip.go
@@ -17,6 +17,17 @@ var (
 		"It's **{{.Side}}**",
 		"What the **{{.Side}}** doing?",
 		"**{{.Side}}**, you hate to see it",
+		"Can you believe it? **{{.Side}}**, only two weeks away!",
+		"Now that **{{.Side}}** is gone",
+		"**{{.Side}}**, HOW!?",
+		"Uh oh, **{{.Side}}**",
+		"**{{.Side}}**, I believe",
+		"When's Guild **{{.Side}}** night?",
+		"Wow, they have it! **{{.Side}}**",
+		"Where's your 4 **{{.Side}}**?",
+		"I can shoot four **{{.Side}}**",
+		"I'm gonna **{{.Side}}**",
+		"Jeffery Epstein didn't kill himself. Oh and I got **{{.Side}}**",
 	}
 )
 

--- a/src/internal/command/coinflip/coinflip_test.go
+++ b/src/internal/command/coinflip/coinflip_test.go
@@ -1,0 +1,32 @@
+package coinflip
+
+import (
+	"io"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	log.SetOutput(io.Discard)
+	os.Exit(m.Run())
+}
+
+func TestCoinFlip(t *testing.T) {
+	cases := []struct {
+		name   string
+		expect []string
+	}{
+		{
+			name:   "when the function runs, return either heads or tails",
+			expect: sides,
+		},
+	}
+
+	for _, test := range cases {
+		result := coinFlip()
+		assert.Contains(t, test.expect, result)
+	}
+}

--- a/src/internal/command/coinflip/coinflip_test.go
+++ b/src/internal/command/coinflip/coinflip_test.go
@@ -30,3 +30,72 @@ func TestCoinFlip(t *testing.T) {
 		assert.Contains(t, test.expect, result)
 	}
 }
+
+func TestSelectPhrase(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  []string
+		expect []string
+	}{
+		{
+			name:   "when the function runs, return a phrase",
+			input:  []string{"phrase one", "phrase two", "phrase three"},
+			expect: []string{"phrase one", "phrase two", "phrase three"},
+		},
+	}
+
+	for _, test := range cases {
+		result := selectPhrase(test.input)
+		assert.Contains(t, test.expect, result)
+	}
+}
+
+func TestMakePhrase(t *testing.T) {
+	cases := []struct {
+		name  string
+		input struct {
+			side   string
+			phrase string
+		}
+		expect string
+	}{
+		{
+			name: "when a phrase has a placeholder at the end of the template, it is substituted with the chosen coin side",
+			input: struct {
+				side   string
+				phrase string
+			}{
+				side:   "Heads",
+				phrase: "It's **{{.Side}}**",
+			},
+			expect: "It's **Heads**",
+		},
+		{
+			name: "when a phrase has a placeholder at the start of the template, it is substituted with the chosen coin side",
+			input: struct {
+				side   string
+				phrase string
+			}{
+				side:   "Tails",
+				phrase: "**{{.Side}}**, you hate to see it",
+			},
+			expect: "**Tails**, you hate to see it",
+		},
+		{
+			name: "when a phrase has a placeholder in the middle of the template, it is substituted with the chosen coin side",
+			input: struct {
+				side   string
+				phrase string
+			}{
+				side:   "Tails",
+				phrase: "What the **{{.Side}}** doing?",
+			},
+			expect: "What the **Tails** doing?",
+		},
+	}
+
+	for _, test := range cases {
+		result := makePhrase(test.input.side, test.input.phrase)
+		assert.Equal(t, test.expect, result)
+	}
+}

--- a/src/internal/discord/service.go
+++ b/src/internal/discord/service.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 
+	"ralphbot/internal/command/coinflip"
 	"ralphbot/internal/command/dadjoke"
 	"ralphbot/internal/command/guidefetch"
 	"ralphbot/internal/command/linkdump"
@@ -48,6 +49,18 @@ func StartBotService(ds *DiscordSession, env *config.EnvConfig) error {
 		return err
 	}
 	defer ds.Close()
+
+	// coin flip
+	commandHandlerCF, err := coinflip.GetCommandHandlers()
+	if err != nil {
+		err = fmt.Errorf("unable to prepare command handlers for %v error: %v", "coinflip", err)
+		return err
+	}
+	_, err = registerCommand(ds, env.GuildID, coinflip.GetCommands(), commandHandlerCF)
+	if err != nil {
+		err = fmt.Errorf("unable to register command %v error: %v", "coinflip", err)
+		return err
+	}
 
 	// guide fetch
 	commandOptionsGF, err := guidefetch.GenerateCommandOptions(guidefetch.Guides)


### PR DESCRIPTION
# Purpose :dart:

These changes introduce the "coin-flip" command for `ralphbot`. This command can be used to settle choices of a binary nature. In addition to the outcome of the coin flip, we also have whacky phrases 👀 

# Context :brain:

A Guildie asked for a coin-flipping command because we don't trust screen-sharing coin flips from Google.
