### PR TITLE
refactor: random string selection is repeating code, and getLinks does too much

### DIFF
--- a/src/internal/command/coinflip/coinflip.go
+++ b/src/internal/command/coinflip/coinflip.go
@@ -3,9 +3,8 @@ package coinflip
 import (
 	"bytes"
 	"log"
-	"math/rand"
+	"ralphbot/internal/common"
 	"text/template"
-	"time"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -30,17 +29,6 @@ var (
 		"Jeffery Epstein didn't kill himself. Oh and I got **{{.Side}}**",
 	}
 )
-
-func coinFlip() string {
-	selectedSide := sides[rand.Intn(len(sides))]
-	return selectedSide
-}
-
-func selectPhrase(phrases []string) string {
-	rand.NewSource(time.Now().UnixNano())
-	selectedPhrase := phrases[rand.Intn(len(phrases))]
-	return selectedPhrase
-}
 
 func makePhrase(side string, phrase string) string {
 	// coin sides are always strings, though we need to use a struct to satisfy template execution
@@ -78,7 +66,7 @@ func GetCommandHandlers() (map[string]func(s *discordgo.Session, i *discordgo.In
 			err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
 				Data: &discordgo.InteractionResponseData{
-					Content: makePhrase(coinFlip(), selectPhrase(phrases)),
+					Content: makePhrase(common.SelectRandomString(sides), common.SelectRandomString(phrases)),
 				},
 			})
 			if err != nil {

--- a/src/internal/command/coinflip/coinflip_test.go
+++ b/src/internal/command/coinflip/coinflip_test.go
@@ -14,42 +14,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestCoinFlip(t *testing.T) {
-	cases := []struct {
-		name   string
-		expect []string
-	}{
-		{
-			name:   "when the function runs, return either heads or tails",
-			expect: sides,
-		},
-	}
-
-	for _, test := range cases {
-		result := coinFlip()
-		assert.Contains(t, test.expect, result)
-	}
-}
-
-func TestSelectPhrase(t *testing.T) {
-	cases := []struct {
-		name   string
-		input  []string
-		expect []string
-	}{
-		{
-			name:   "when the function runs, return a phrase",
-			input:  []string{"phrase one", "phrase two", "phrase three"},
-			expect: []string{"phrase one", "phrase two", "phrase three"},
-		},
-	}
-
-	for _, test := range cases {
-		result := selectPhrase(test.input)
-		assert.Contains(t, test.expect, result)
-	}
-}
-
 func TestMakePhrase(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/src/internal/command/dadjoke/dadjoke.go
+++ b/src/internal/command/dadjoke/dadjoke.go
@@ -5,7 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"math/rand"
+
+	"ralphbot/internal/common"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -25,12 +26,6 @@ func getJokes(b []byte) ([]string, error) {
 		return nil, fmt.Errorf("unable to unmarshal json: %v", err)
 	}
 	return jokeArray.Jokes, nil
-}
-
-func selectDadJoke(j []string) string {
-	selectedDadJoke := j[rand.Intn(len(j))]
-	result := string(selectedDadJoke)
-	return result
 }
 
 func GetCommands() []*discordgo.ApplicationCommand {
@@ -54,7 +49,7 @@ func GetCommandHandlers() (map[string]func(s *discordgo.Session, i *discordgo.In
 			err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
 				Data: &discordgo.InteractionResponseData{
-					Content: selectDadJoke(jokes),
+					Content: common.SelectRandomString(jokes), //selectDadJoke(jokes),
 				},
 			})
 			if err != nil {

--- a/src/internal/command/dadjoke/dadjoke_test.go
+++ b/src/internal/command/dadjoke/dadjoke_test.go
@@ -87,31 +87,3 @@ func TestGetJokes(t *testing.T) {
 		}
 	}
 }
-
-func TestSelectDadJoke(t *testing.T) {
-	cases := []struct {
-		name  string
-		input []string
-	}{
-		{
-			name: "given 3 jokes, selectDadJoke will randomly pick a joke",
-			input: []string{
-				"option 1",
-				"option 2",
-				"option 3",
-			},
-		},
-	}
-
-	for _, test := range cases {
-		result := selectDadJoke(test.input)
-
-		// testing for probability i.e. does our result show up at least once? This is more of a "transparency" test
-		var resultTally []string
-		for i := 0; i < 1000; i++ {
-			resultTally = append(resultTally, selectDadJoke(test.input))
-		}
-
-		assert.Contains(t, resultTally, result)
-	}
-}

--- a/src/internal/command/dadjoke/dadjoke_test.go
+++ b/src/internal/command/dadjoke/dadjoke_test.go
@@ -17,7 +17,7 @@ func TestMain(m *testing.M) {
 func TestGetJokes(t *testing.T) {
 	cases := []struct {
 		name   string
-		input  string
+		input  []byte
 		expect struct {
 			result struct {
 				slice        []string
@@ -27,13 +27,13 @@ func TestGetJokes(t *testing.T) {
 	}{
 		{
 			name: "with a json array length of 3, getJokes returns a slice with length of 3",
-			input: `{
+			input: []byte(`{
 						"jokes": [
 							"the joke is this test suite",
 							"not really",
 							"unless?"
 						]
-					}`,
+					}`),
 			expect: struct {
 				result struct {
 					slice        []string
@@ -50,11 +50,11 @@ func TestGetJokes(t *testing.T) {
 		},
 		{
 			name: "when a bad json input is provided, getJokes returns a slice with length of 0, and an error",
-			input: `{
+			input: []byte(`{
 				"bad-json": {
 					notAValidKey: true
 				}
-			}`,
+			}`),
 			expect: struct {
 				result struct {
 					slice        []string

--- a/src/internal/command/linkdump/linkdump.go
+++ b/src/internal/command/linkdump/linkdump.go
@@ -16,7 +16,7 @@ type LinkDetails struct {
 }
 
 type Links struct {
-	Links []LinkDetails `json:"Links"`
+	Links []LinkDetails `json:"links"`
 }
 
 //go:embed links.json

--- a/src/internal/command/linkdump/linkdump_test.go
+++ b/src/internal/command/linkdump/linkdump_test.go
@@ -28,7 +28,7 @@ func TestGetLinks(t *testing.T) {
 		{
 			name: "when one link is provided as input, the string contains one link",
 			input: `{
-				"Links": [
+				"links": [
 					{
 					  "Name": "foo",
 					  "URL": "foo.com"
@@ -40,7 +40,7 @@ func TestGetLinks(t *testing.T) {
 		{
 			name: "when 2 links are provided as input, the string contains two links, seperated by newline",
 			input: `{
-				"Links": [
+				"links": [
 					{
 					  "Name": "foo",
 					  "URL": "foo.com"

--- a/src/internal/command/linkdump/linkdump_test.go
+++ b/src/internal/command/linkdump/linkdump_test.go
@@ -15,31 +15,34 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestGetLinks(t *testing.T) {
-
-	foo := "foo - <foo.com>"
-	bar := "bar - <bar.com>"
-
+func TestGetLinksFromJSON(t *testing.T) {
 	cases := []struct {
 		name     string
-		input    string
-		expected string
+		input    []byte
+		expected LinksStruct
 	}{
 		{
-			name: "when one link is provided as input, the string contains one link",
-			input: `{
+			name: "when one link is provided as input, the struct contains one unmarshalled link",
+			input: []byte(`{
 				"links": [
 					{
 					  "Name": "foo",
 					  "URL": "foo.com"
 					}
 				]
-			}`,
-			expected: foo,
+			}`),
+			expected: LinksStruct{
+				Links: []LinkDetails{
+					{
+						Name: "foo",
+						URL:  "foo.com",
+					},
+				},
+			},
 		},
 		{
-			name: "when 2 links are provided as input, the string contains two links, seperated by newline",
-			input: `{
+			name: "when one link is provided as input, the struct contains one unmarshalled link",
+			input: []byte(`{
 				"links": [
 					{
 					  "Name": "foo",
@@ -50,14 +53,70 @@ func TestGetLinks(t *testing.T) {
 					  "URL": "bar.com"
 					}
 				]
-			}`,
-			expected: fmt.Sprintf("%s\n%s", foo, bar),
+			}`),
+			expected: LinksStruct{
+				Links: []LinkDetails{
+					{
+						Name: "foo",
+						URL:  "foo.com",
+					},
+					{
+						Name: "bar",
+						URL:  "bar.com",
+					},
+				},
+			},
 		},
 	}
 
 	for _, test := range cases {
-		result, err := getLinks([]byte(test.input))
+		result, err := getLinksFromJSON([]byte(test.input))
 		assert.NoError(t, err)
 		assert.Equal(t, test.expected, result)
+	}
+}
+
+func TestMakeLinkDumpMessage(t *testing.T) {
+	foo := "foo - <foo.com>"
+	bar := "bar - <bar.com>"
+
+	cases := []struct {
+		name   string
+		input  LinksStruct
+		expect string
+	}{
+		{
+			name: "when the input LinksStruct contains one link, return one link in the string",
+			input: LinksStruct{
+				Links: []LinkDetails{
+					{
+						Name: "foo",
+						URL:  "foo.com",
+					},
+				},
+			},
+			expect: fmt.Sprintf("%v", foo),
+		},
+		{
+			name: "when the input LinksStruct contains two links, return two links in the string, seperated by newline",
+			input: LinksStruct{
+				Links: []LinkDetails{
+					{
+						Name: "foo",
+						URL:  "foo.com",
+					},
+					{
+						Name: "bar",
+						URL:  "bar.com",
+					},
+				},
+			},
+			expect: fmt.Sprintf("%v\n%v", foo, bar),
+		},
+	}
+
+	for _, test := range cases {
+		result := makeLinkDumpMessage(test.input)
+		assert.Equal(t, test.expect, result)
 	}
 }

--- a/src/internal/command/linkdump/links.json
+++ b/src/internal/command/linkdump/links.json
@@ -1,5 +1,5 @@
 {
-  "Links": [
+  "links": [
     {
       "Name": "Bray.Tech",
       "URL": "https://bray.tech/"

--- a/src/internal/common/common.go
+++ b/src/internal/common/common.go
@@ -1,0 +1,12 @@
+package common
+
+import (
+	"math/rand"
+	"time"
+)
+
+func SelectRandomString(s []string) string {
+	rand.NewSource(time.Now().UnixNano())
+	selectedString := s[rand.Intn(len(s))]
+	return selectedString
+}

--- a/src/internal/common/common_test.go
+++ b/src/internal/common/common_test.go
@@ -1,0 +1,35 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelectRandomString(t *testing.T) {
+	cases := []struct {
+		name  string
+		input []string
+	}{
+		{
+			name: "given 3 elements in a slice, SelectRandomString will randomly pick an element",
+			input: []string{
+				"option 1",
+				"option 2",
+				"option 3",
+			},
+		},
+	}
+
+	for _, test := range cases {
+		result := SelectRandomString(test.input)
+
+		// testing for probability i.e. does our result show up at least once? This is more of a "transparency" test
+		var resultTally []string
+		for i := 0; i < 1000; i++ {
+			resultTally = append(resultTally, SelectRandomString(test.input))
+		}
+
+		assert.Contains(t, resultTally, result)
+	}
+}


### PR DESCRIPTION
# Purpose :dart:

These changes do the following:

- Move random string selection logic common to `dadjoke` and `coinflip` into a shared function. This makes future changes to the logic easier to manage.
- `getLinks` did too much as a function, so it's been decomposed into two separate functions. One that unmrashals the byte slice into a struct, and the other that takes the struct and transforms it into a newline-separated string.

# Context :brain:

These changes were low-hanging fruit items that were personally bothering me.
