### PR TITLE
feat: Add asdf renovate tweak 

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,17 +27,17 @@
   "packageRules": [
     {
       "automerge": true,
+      "matchManagers": ["github-actions"]
+    },
+    {
+      "automerge": true,
+      "matchManagers": ["gomod"]
+    },
+    {
+      "automerge": true,
       "matchManagers": ["npm"],
       "excludeDepPatterns": ["node"],
       "matchUpdateTypes": ["minor", "patch", "rollback", "bump"]
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "automerge": true
-    },
-    {
-      "matchManagers": ["gomod"],
-      "automerge": true
     },
     {
       "groupName": "aws-cdk",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,6 +27,10 @@
   "packageRules": [
     {
       "automerge": true,
+      "matchManagers": ["asdf"]
+    },
+    {
+      "automerge": true,
       "matchManagers": ["github-actions"]
     },
     {


### PR DESCRIPTION
# Purpose :dart:

This change adds a top-level `asdf` package rule for `renovate`. This is so that `renovate` at a top-level knows it can automerge dependencies defined in `.tool-versions` unless indicated otherwise further into the configuration.

# Context :brain:

This change was spurred from a need to enable auto-merging of #489 
