### PR TITLE
ci: Adds cdk concurrency and swaps npx for pnpm execution

### DIFF
--- a/ops/cdk.json
+++ b/ops/cdk.json
@@ -1,5 +1,5 @@
 {
-  "app": "npx ts-node --prefer-ts-exts src/index.ts",
+  "app": "pnpm ts-node --prefer-ts-exts src/index.ts",
   "watch": {
     "include": ["**"],
     "exclude": [

--- a/ops/package.json
+++ b/ops/package.json
@@ -16,7 +16,7 @@
     "lint": "pnpm -s eslint && pnpm -s prettier",
     "lint:fix": "tsc && pnpm -s eslint --fix && pnpm -s prettier --write",
     "deploy": "cdk deploy '*' --require-approval never",
-    "ci-deploy": "cdk deploy '*' --require-approval never --progress events"
+    "ci-deploy": "cdk deploy '*' --require-approval never --progress events --concurrency 2"
   },
   "devDependencies": {
     "@types/jest": "29.5.1",


### PR DESCRIPTION
# Purpose :dart:

These changes tweak the operability of `ralphbot`'s CI through the `ops` stack code.

- The `npx` call was replaced with `pnpm` in order to remove the `npm` alerts during deploy time. This gets rid of some logging cruft, and _may_ improve performance by using pnpm.

- Concurrency was added in AWS CDK for a while now, and this could be an opportunity to slightly speed up things. Barring dependencies between stacks, AWS CDK will attempt to execute 2 deployments at a time.

# Context :brain:

No real context here. This is minor housekeeping that I had in mind and had time to do.
