### PR TITLE
chore: Ralphbot stands up quick, healthcheck grace period can be shorter

### DIFF
--- a/ops/__tests__/__snapshots__/ralphbot-ops-stack.test.ts.snap
+++ b/ops/__tests__/__snapshots__/ralphbot-ops-stack.test.ts.snap
@@ -34,6 +34,7 @@ exports[`Retrieve ralphbot ECR Stack Synths and snapshots 1`] = `
           "Type": "ECS",
         },
         "EnableECSManagedTags": false,
+        "HealthCheckGracePeriodSeconds": 10,
         "LaunchType": "FARGATE",
         "NetworkConfiguration": {
           "AwsvpcConfiguration": {

--- a/ops/src/stacks/ralphbot-ops-stack.ts
+++ b/ops/src/stacks/ralphbot-ops-stack.ts
@@ -1,6 +1,6 @@
+import * as cdk from "aws-cdk-lib"
 import { AppExtensionProps } from "../app"
 import { Construct } from "constructs"
-import { Stack, StackProps } from "aws-cdk-lib"
 import { aws_ec2 as ec2 } from "aws-cdk-lib"
 import { aws_ecr as ecr } from "aws-cdk-lib"
 import { aws_ecs as ecs } from "aws-cdk-lib"
@@ -9,11 +9,11 @@ import { aws_logs as logs } from "aws-cdk-lib"
 import { aws_secretsmanager as secretsmanager } from "aws-cdk-lib"
 import { aws_ssm as ssm } from "aws-cdk-lib"
 
-export class RalphbotStack extends Stack {
+export class RalphbotStack extends cdk.Stack {
   constructor(
     scope: Construct,
     id: string,
-    props?: StackProps,
+    props?: cdk.StackProps,
     extendedProps?: AppExtensionProps
   ) {
     super(scope, id, props)
@@ -82,6 +82,7 @@ export class RalphbotStack extends Stack {
     new ecs.FargateService(this, "Service", {
       assignPublicIp: true,
       cluster: cluster,
+      healthCheckGracePeriod: cdk.Duration.seconds(10),
       taskDefinition: taskDefinition,
       circuitBreaker: { rollback: true },
       vpcSubnets: vpc.selectSubnets({


### PR DESCRIPTION
# Purpose :dart:

This change aims to speed up `ralphbot`'s deployment time by 50 seconds. By default, Fargate Services provide a 60-second grace period before running the first health-check for when a new service task stands up. Locally, `ralphbot` stands up pretty quick, so we can reduce this wait time to a level that makes sense (10 for now, but could be reduced further). For reference,`ralphbot` takes ~ 7 minutes to deploy.

# Context :brain:

I have a need for speed 🔥 
