### PR TITLE
Revert "chore: Ralphbot stands up quick, healthcheck grace period can be shorter (#513)"

### DIFF
--- a/ops/__tests__/__snapshots__/ralphbot-ops-stack.test.ts.snap
+++ b/ops/__tests__/__snapshots__/ralphbot-ops-stack.test.ts.snap
@@ -34,7 +34,6 @@ exports[`Retrieve ralphbot ECR Stack Synths and snapshots 1`] = `
           "Type": "ECS",
         },
         "EnableECSManagedTags": false,
-        "HealthCheckGracePeriodSeconds": 10,
         "LaunchType": "FARGATE",
         "NetworkConfiguration": {
           "AwsvpcConfiguration": {

--- a/ops/src/stacks/ralphbot-ops-stack.ts
+++ b/ops/src/stacks/ralphbot-ops-stack.ts
@@ -1,6 +1,6 @@
-import * as cdk from "aws-cdk-lib"
 import { AppExtensionProps } from "../app"
 import { Construct } from "constructs"
+import { Stack, StackProps } from "aws-cdk-lib"
 import { aws_ec2 as ec2 } from "aws-cdk-lib"
 import { aws_ecr as ecr } from "aws-cdk-lib"
 import { aws_ecs as ecs } from "aws-cdk-lib"
@@ -9,11 +9,11 @@ import { aws_logs as logs } from "aws-cdk-lib"
 import { aws_secretsmanager as secretsmanager } from "aws-cdk-lib"
 import { aws_ssm as ssm } from "aws-cdk-lib"
 
-export class RalphbotStack extends cdk.Stack {
+export class RalphbotStack extends Stack {
   constructor(
     scope: Construct,
     id: string,
-    props?: cdk.StackProps,
+    props?: StackProps,
     extendedProps?: AppExtensionProps
   ) {
     super(scope, id, props)
@@ -82,7 +82,6 @@ export class RalphbotStack extends cdk.Stack {
     new ecs.FargateService(this, "Service", {
       assignPublicIp: true,
       cluster: cluster,
-      healthCheckGracePeriod: cdk.Duration.seconds(10),
       taskDefinition: taskDefinition,
       circuitBreaker: { rollback: true },
       vpcSubnets: vpc.selectSubnets({


### PR DESCRIPTION
This reverts commit 7241088d12d5c0ac2f32e3ff334733f65152db2a.

healthCheckGracePeriod is only applicable to Fargate services behind LoadBalancers.
