### PR TITLE
chore: Add regexManager rule for `pnpm/setup-pnpm` versioning

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -94,5 +94,13 @@
       "matchPackageNames": ["node"],
       "matchUpdateTypes": ["minor"]
     }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["./workflows/ralphbot-ops-lint.yaml"],
+      "matchStrings": [
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?_VERSION=(?<currentValue>.*)\\s"
+      ]
+    }
   ]
 }

--- a/.github/workflows/ralphbot-ops-lint.yaml
+++ b/.github/workflows/ralphbot-ops-lint.yaml
@@ -23,6 +23,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2
         with:
+          # renovate: datasource=github-releases depName=pnpm/pnpm versioning=semver
           version: 8.5.0 # The action doesn't support specifying a directory for package.json. So this has to be hard-coded for now
 
       - uses: actions/setup-node@v3


### PR DESCRIPTION
# Purpose :dart:

These changes enable `renovate` to manage versioning of `pnpm` within the `pnpm/setup-pnpm` Github Action along with the rest of the mentioned `pnpm` dependencies.

# Context :brain:

- `pnpm` was updated to [8.6.0](https://github.com/therealvio-org/ralphbot/pull/522), though the action wasn't being managed. Renovate _still_ merged this even with failing tests.
- Fixes broken linting for the `ops` stack.