### PR TITLE
chore: Add shared version control for all implementations of `pnpm`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -93,6 +93,20 @@
       "matchManagers": ["dockerfile"],
       "matchPackageNames": ["node"],
       "matchUpdateTypes": ["minor"]
+    },
+    {
+      "groupName": "pnpm",
+      "automerge": false,
+      "matchManagers": ["regex", "asdf", "npm"],
+      "matchPackageNames": ["pnpm", "pnpm/pnpm"]
+    }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^.github/(?:workflows|actions)/.+\\.ya?ml$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[a-z-0-9]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
+      ]
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -57,6 +57,11 @@
       "rangeStrategy": "bump"
     },
     {
+      "groupName": "jest",
+      "automerge": true,
+      "matchPackageNames": ["jest", "ts-jest", "@types/jest"]
+    },
+    {
       "groupName": "linting",
       "automerge": true,
       "matchPackageNames": [
@@ -66,11 +71,6 @@
         "eslint-plugin-import",
         "prettier"
       ]
-    },
-    {
-      "groupName": "jest",
-      "automerge": true,
-      "matchPackageNames": ["jest", "ts-jest", "@types/jest"]
     },
     {
       "groupName": "nodejs",

--- a/.github/workflows/ralphbot-ops-lint.yaml
+++ b/.github/workflows/ralphbot-ops-lint.yaml
@@ -7,6 +7,10 @@ on:
       - "ops/**"
       - ".github/workflows/ralphbot-ops-lint.yaml"
 
+env:
+  # renovate: datasource=github-releases depName=pnpm/pnpm versioning=semver
+  PNPM_VERSION: v8.5.0
+
 jobs:
   cdk-test:
     strategy:
@@ -23,7 +27,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2
         with:
-          version: 8.5.0 # The action doesn't support specifying a directory for package.json. So this has to be hard-coded for now
+          version: ${{PNPM_VERSION}}
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
# Purpose :dart:

Version management for the Github action `pnpm/setup-pnpm` has been added via a regexManager rule. In addition to this, a packageRule for `pnpm` has been added to bring all `pnpm` versioning together. The regexManager rule is based on a pre-existing pattern made by renovate.

This change has been added due to a limitation of the action not having a means to specify a directory where a `package.json` can live. This means rather than relying on the versioning of a package manager specified in there, a version has to be set for the action.

# Context :brain:

`pnpm` was updating in all places but the Github action.


# Notes 📓 

- https://docs.renovatebot.com/modules/manager/regex/
- https://docs.renovatebot.com/presets-regexManagers/