### PR TITLE
feat: Adds Ghosts of the Deep guide link

### DIFF
--- a/src/internal/command/guidefetch/guide.go
+++ b/src/internal/command/guidefetch/guide.go
@@ -23,6 +23,13 @@ var (
 		GDriveLink:     "https://drive.google.com/drive/folders/1pPdtAptJMaaDYRv2i-8bfaL6l3I0WTsT?usp=sharing",
 	}
 
+	ghosts = &guide{
+		Name:           "Ghosts of the Deep",
+		SubCommandName: "dungeon-ghosts",
+		Description:    "Ghosts of the Deep Dungeon",
+		GDriveLink:     "https://drive.google.com/drive/folders/1vyJqLgcVsBkymHKMY8vYRENUWA2kESES?usp=sharing",
+	}
+
 	kingsfall = &guide{
 		Name:           "King's Fall",
 		SubCommandName: "raid-kingsfall",
@@ -76,6 +83,7 @@ var (
 	Guides = []guide{
 		*crypt,
 		*garden,
+		*ghosts,
 		*kingsfall,
 		*pit,
 		*ron,


### PR DESCRIPTION
# Purpose :dart:

This change adds the Ghosts of the Deep raid guide link. Like any other guide link, this change makes our activity resources accessible on Google Drive. What else do you want?

# Context :brain:

The Ghosts of the Deep dungeon is out, and some good material is out.
