### PR TITLE
chore: Enables automerge for pnpm depdency

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -96,7 +96,7 @@
     },
     {
       "groupName": "pnpm",
-      "automerge": false,
+      "automerge": true,
       "matchManagers": ["regex", "asdf", "npm"],
       "matchPackageNames": ["pnpm", "pnpm/pnpm"]
     }


### PR DESCRIPTION
# Purpose :dart:

This change enables the `renovate` configuration for the `pnpm` dependency updates to be automerged.

# Context :brain:

This was disabled while verifying update behaviour. Seeing that #547 looks good, we can enable automerge.
