### PR TITLE
chore: attempt to fix renovate automerge annoyances

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,37 +24,33 @@
   "platformAutomerge": true,
   "automergeStrategy": "squash",
   "automergeType": "pr",
+  "automerge": true,
   "packageRules": [
-    { "automerge": true, "matchManagers": ["asdf"] },
-    { "automerge": true, "matchManagers": ["github-actions"] },
-    { "automerge": true, "matchManagers": ["gomod"] },
+    { "matchManagers": ["asdf"] },
+    { "matchManagers": ["github-actions"] },
+    { "matchManagers": ["gomod"] },
     {
-      "automerge": true,
       "matchManagers": ["npm"],
       "excludeDepPatterns": ["node"],
       "matchUpdateTypes": ["minor", "patch", "rollback", "bump"]
     },
     {
       "groupName": "aws-cdk",
-      "automerge": true,
       "allowedVersions": "^2.0.0",
       "matchPackageNames": ["aws-cdk", "aws-cdk-lib"]
     },
     {
       "groupName": "golang",
-      "automerge": true,
       "matchDatasources": ["golang-version"],
       "matchManagers": ["asdf", "dockerfile", "gomod"],
       "rangeStrategy": "bump"
     },
     {
       "groupName": "jest",
-      "automerge": true,
       "matchPackageNames": ["jest", "ts-jest", "@types/jest"]
     },
     {
       "groupName": "linting",
-      "automerge": true,
       "matchPackageNames": [
         "@typescript-eslint/eslint-plugin",
         "@typescript-eslint/parser",
@@ -65,14 +61,12 @@
     },
     {
       "groupName": "nodejs",
-      "automerge": true,
       "allowedVersions": "^18.0.0",
       "matchManagers": ["npm"],
       "matchPackageNames": ["node", "@types/node"]
     },
     {
       "groupName": "nodejs",
-      "automerge": true,
       "allowedVersions": "^18.0.0",
       "matchDatasources": ["node-version"],
       "matchManagers": ["asdf"],
@@ -87,7 +81,6 @@
     },
     {
       "groupName": "pnpm",
-      "automerge": true,
       "matchManagers": ["regex", "asdf", "npm"],
       "matchPackageNames": ["pnpm", "pnpm/pnpm"]
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,7 +18,7 @@
     "schedule": ["after 7am on the first day of the month"],
     "automerge": true,
     "automergeType": "pr",
-    "platformAutomerge": true,
+    "platformAutomerge": false,
     "automergeStrategy": "squash"
   },
   "platformAutomerge": true,

--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -1,12 +1,8 @@
 name: renovate-config-validator
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
-    branches:
-      - main
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Purpose :dart:

These changes are aimed at making `renovate` work for me, rather than me working for it. This is accomplished by paring down features, and making the configuration simpler based on my learnings about `renovate`.

# Context :brain:

`renovate` is _really_ getting on my nerves with these constant configuration tweaks. Work consistently, dammit!
