### PR TITLE
Revert "chore: Run prettier 3.0.0 changes"

### DIFF
--- a/ops/__tests__/ralphbot-ops-stack.test.ts
+++ b/ops/__tests__/ralphbot-ops-stack.test.ts
@@ -29,7 +29,7 @@ describe("Retrieve ralphbot ECR Stack", () => {
         region: region,
       },
     },
-    extendedProperties,
+    extendedProperties
   )
 
   const template = Template.fromStack(stack)

--- a/ops/package.json
+++ b/ops/package.json
@@ -30,7 +30,7 @@
     "eslint-plugin-only-warn": "1.1.0",
     "eslint-plugin-sort-imports-es6-autofix": "0.6.0",
     "jest": "29.6.1",
-    "prettier": "3.0.0",
+    "prettier": "2.8.8",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",
     "typescript": "5.1.6"

--- a/ops/pnpm-lock.yaml
+++ b/ops/pnpm-lock.yaml
@@ -50,8 +50,8 @@ devDependencies:
     specifier: 29.6.1
     version: 29.6.1(@types/node@18.16.19)(ts-node@10.9.1)
   prettier:
-    specifier: 3.0.0
-    version: 3.0.0
+    specifier: 2.8.8
+    version: 2.8.8
   ts-jest:
     specifier: 29.1.1
     version: 29.1.1(@babel/core@7.22.5)(jest@29.6.1)(typescript@5.1.6)
@@ -3200,9 +3200,9 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier@3.0.0:
-    resolution: {integrity: sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==}
-    engines: {node: '>=14'}
+  /prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+    engines: {node: '>=10.13.0'}
     hasBin: true
     dev: true
 

--- a/ops/src/index.ts
+++ b/ops/src/index.ts
@@ -45,5 +45,5 @@ new RalphbotStack(
       region: region,
     },
   },
-  extendedProperties,
+  extendedProperties
 )

--- a/ops/src/stacks/ralphbot-ops-stack.ts
+++ b/ops/src/stacks/ralphbot-ops-stack.ts
@@ -14,7 +14,7 @@ export class RalphbotStack extends Stack {
     scope: Construct,
     id: string,
     props?: StackProps,
-    extendedProps?: AppExtensionProps,
+    extendedProps?: AppExtensionProps
   ) {
     super(scope, id, props)
 
@@ -26,12 +26,12 @@ export class RalphbotStack extends Stack {
     const repositoryRef = ecr.Repository.fromRepositoryArn(
       this,
       "ralphbotECRRepositoryRef",
-      `arn:aws:ecr:${props?.env?.region}:${props?.env?.account}:repository/ralphbot/master`,
+      `arn:aws:ecr:${props?.env?.region}:${props?.env?.account}:repository/ralphbot/master`
     )
 
     const ralphbotImage = ecs.ContainerImage.fromEcrRepository(
       repositoryRef,
-      extendedProps?.version,
+      extendedProps?.version
     )
 
     const cluster = new ecs.Cluster(this, "Cluster", {
@@ -46,17 +46,17 @@ export class RalphbotStack extends Stack {
         runtimePlatform: {
           cpuArchitecture: ecs.CpuArchitecture.ARM64,
         },
-      },
+      }
     )
 
     const botToken = secretsmanager.Secret.fromSecretNameV2(
       this,
       "botTokenFromName",
-      "ralphbot/token",
+      "ralphbot/token"
     )
     const secretArnSuffix = ssm.StringParameter.valueForStringParameter(
       this,
-      "/ralphbot/token/arn-suffix",
+      "/ralphbot/token/arn-suffix"
     )
 
     taskDefinition.addToExecutionRolePolicy(
@@ -66,7 +66,7 @@ export class RalphbotStack extends Stack {
           "secretsmanager:DescribeSecret",
         ],
         resources: [`${botToken.secretArn}-${secretArnSuffix}`],
-      }),
+      })
     )
 
     taskDefinition.addContainer("ralphbotContainer", {


### PR DESCRIPTION
# Purpose :dart:

This is part of an effort to test `renovate` automerging behaviour where `renovate` *should* be waiting for status checks to pass before merging.

These particular reverts are intended to replicate a scenario where a dependency update will occur, and _will_ require intervention to address the failing status check. What we want to see is `renovate` not merge the PR in a subsequent run.