### PR TITLE
ci: enhance workflow trigger paths

### DIFF
--- a/.github/workflows/ralphbot-ops-lint.yaml
+++ b/.github/workflows/ralphbot-ops-lint.yaml
@@ -5,7 +5,7 @@ on:
   push:
     paths:
       - "ops/**"
-      - ".github/workflows/ralphbot-ops-lint.yaml"
+      - ".github/workflows/**"
 
 env:
   # renovate: datasource=github-releases depName=pnpm/pnpm versioning=semver

--- a/.github/workflows/ralphbot-src-lint.yaml
+++ b/.github/workflows/ralphbot-src-lint.yaml
@@ -5,7 +5,7 @@ on:
   push:
     paths:
       - "src/**"
-      - ".github/workflows/ralphbot-src-lint.yaml"
+      - ".github/workflows/**"
 
 env:
   WORK_DIR: ./src

--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -2,6 +2,9 @@ name: renovate-config-validator
 
 on:
   push:
+    paths:
+      - "**/renovate.json"
+      - ".github/workflows/**"
 
 jobs:
   validate:


### PR DESCRIPTION
# Purpose :dart:

The workflow trigger paths for the `renovate-config` linter was non-existent and would run on each PR. This isn't necessary, since it only needs to watch out for the workflow directory itself, as well as the `renovate.json` file.

As for the other linters, they were specified to only watch out for their own workflow filepaths, in addition to the code directories they were responsible for. By changing the path to the directory where the workflow lives itself, it accounts for if and when the files are renamed 🧠. 

# Context :brain:

I figured the workflows could be a lot smarter than they are right now 😛 
